### PR TITLE
feat: Add imports and string_imports attributes

### DIFF
--- a/d/private/providers.bzl
+++ b/d/private/providers.bzl
@@ -3,22 +3,22 @@
 def _dinfo_init(
         *,
         compile_flags = None,
-        import_paths = None,
         imports = None,
+        interface_srcs = None,
         libraries = None,
         linker_flags = None,
         source_only = False,
-        string_import_paths = None,
+        string_imports = None,
         versions = None):
     """Initializes the DInfo provider."""
     return {
         "compile_flags": compile_flags or [],
-        "import_paths": import_paths or depset(),
         "imports": imports or depset(),
+        "interface_srcs": interface_srcs or depset(),
         "libraries": libraries or depset(),
         "linker_flags": linker_flags or [],
         "source_only": source_only,
-        "string_import_paths": string_import_paths or depset(),
+        "string_imports": string_imports or depset(),
         "versions": versions or depset(),
     }
 
@@ -26,12 +26,12 @@ DInfo, _new_dinfo = provider(
     doc = "Provider containing D compilation information",
     fields = {
         "compile_flags": "List of compiler flags.",
-        "import_paths": "A depset of import paths.",
-        "imports": "A depset of imported D files, transitive import included.",
+        "imports": "A depset of import paths.",
+        "interface_srcs": "A depset of interface source files, transitive sources included.",
         "libraries": "A depset of libraries, transitive libraries too.",
         "linker_flags": "List of linker flags, passed directly to the linker.",
         "source_only": "If true, the source files are compiled, but no library is produced.",
-        "string_import_paths": "A depset of string import paths.",
+        "string_imports": "A depset of string import paths.",
         "versions": "A depset of version identifiers.",
     },
     init = _dinfo_init,

--- a/d/private/rules/BUILD.bazel
+++ b/d/private/rules/BUILD.bazel
@@ -24,6 +24,7 @@ bzl_library(
     ],
     deps = [
         "//d/private:providers",
+        "@bazel_skylib//lib:paths",
         "@rules_cc//cc/common",
     ],
 )

--- a/d/tests/imports_attribute/BUILD.bazel
+++ b/d/tests/imports_attribute/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_d//d:defs.bzl", "d_binary", "d_library")
+
+d_library(
+    name = "no_prefix_import",
+    srcs = ["path1/no_prefix_import.d"],
+    imports = ["path1"],
+)
+
+d_binary(
+    name = "imports_attribute",
+    srcs = [
+        "main.d",
+    ],
+    deps = [":no_prefix_import"],
+)
+
+build_test(
+    name = "imports_attribute_test",
+    targets = [":imports_attribute"],
+)

--- a/d/tests/imports_attribute/main.d
+++ b/d/tests/imports_attribute/main.d
@@ -1,0 +1,6 @@
+import no_prefix_import;
+
+void main()
+{
+    no_prefix_import.foo();
+}

--- a/d/tests/imports_attribute/path1/no_prefix_import.d
+++ b/d/tests/imports_attribute/path1/no_prefix_import.d
@@ -1,0 +1,6 @@
+import std.stdio;
+
+void foo()
+{
+    writeln("Hello without prefix!");
+}

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -9,7 +9,7 @@ Public API of D rules.
 <pre>
 load("@rules_d//d:defs.bzl", "d_binary")
 
-d_binary(<a href="#d_binary-name">name</a>, <a href="#d_binary-deps">deps</a>, <a href="#d_binary-srcs">srcs</a>, <a href="#d_binary-string_srcs">string_srcs</a>, <a href="#d_binary-versions">versions</a>)
+d_binary(<a href="#d_binary-name">name</a>, <a href="#d_binary-deps">deps</a>, <a href="#d_binary-srcs">srcs</a>, <a href="#d_binary-imports">imports</a>, <a href="#d_binary-string_imports">string_imports</a>, <a href="#d_binary-string_srcs">string_srcs</a>, <a href="#d_binary-versions">versions</a>)
 </pre>
 
 
@@ -22,6 +22,8 @@ d_binary(<a href="#d_binary-name">name</a>, <a href="#d_binary-deps">deps</a>, <
 | <a id="d_binary-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="d_binary-deps"></a>deps |  List of dependencies.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="d_binary-srcs"></a>srcs |  List of D '.d' or '.di' source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="d_binary-imports"></a>imports |  List of import paths.   | List of strings | optional |  `[]`  |
+| <a id="d_binary-string_imports"></a>string_imports |  List of string import paths.   | List of strings | optional |  `[]`  |
 | <a id="d_binary-string_srcs"></a>string_srcs |  List of string import source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="d_binary-versions"></a>versions |  List of version identifiers.   | List of strings | optional |  `[]`  |
 
@@ -33,7 +35,7 @@ d_binary(<a href="#d_binary-name">name</a>, <a href="#d_binary-deps">deps</a>, <
 <pre>
 load("@rules_d//d:defs.bzl", "d_library")
 
-d_library(<a href="#d_library-name">name</a>, <a href="#d_library-deps">deps</a>, <a href="#d_library-srcs">srcs</a>, <a href="#d_library-source_only">source_only</a>, <a href="#d_library-string_srcs">string_srcs</a>, <a href="#d_library-versions">versions</a>)
+d_library(<a href="#d_library-name">name</a>, <a href="#d_library-deps">deps</a>, <a href="#d_library-srcs">srcs</a>, <a href="#d_library-imports">imports</a>, <a href="#d_library-source_only">source_only</a>, <a href="#d_library-string_imports">string_imports</a>, <a href="#d_library-string_srcs">string_srcs</a>, <a href="#d_library-versions">versions</a>)
 </pre>
 
 
@@ -46,7 +48,9 @@ d_library(<a href="#d_library-name">name</a>, <a href="#d_library-deps">deps</a>
 | <a id="d_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="d_library-deps"></a>deps |  List of dependencies.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="d_library-srcs"></a>srcs |  List of D '.d' or '.di' source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="d_library-imports"></a>imports |  List of import paths.   | List of strings | optional |  `[]`  |
 | <a id="d_library-source_only"></a>source_only |  If true, the source files are compiled, but not library is produced.   | Boolean | optional |  `False`  |
+| <a id="d_library-string_imports"></a>string_imports |  List of string import paths.   | List of strings | optional |  `[]`  |
 | <a id="d_library-string_srcs"></a>string_srcs |  List of string import source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="d_library-versions"></a>versions |  List of version identifiers.   | List of strings | optional |  `[]`  |
 
@@ -58,7 +62,7 @@ d_library(<a href="#d_library-name">name</a>, <a href="#d_library-deps">deps</a>
 <pre>
 load("@rules_d//d:defs.bzl", "d_test")
 
-d_test(<a href="#d_test-name">name</a>, <a href="#d_test-deps">deps</a>, <a href="#d_test-srcs">srcs</a>, <a href="#d_test-string_srcs">string_srcs</a>, <a href="#d_test-versions">versions</a>)
+d_test(<a href="#d_test-name">name</a>, <a href="#d_test-deps">deps</a>, <a href="#d_test-srcs">srcs</a>, <a href="#d_test-imports">imports</a>, <a href="#d_test-string_imports">string_imports</a>, <a href="#d_test-string_srcs">string_srcs</a>, <a href="#d_test-versions">versions</a>)
 </pre>
 
 
@@ -71,6 +75,8 @@ d_test(<a href="#d_test-name">name</a>, <a href="#d_test-deps">deps</a>, <a href
 | <a id="d_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="d_test-deps"></a>deps |  List of dependencies.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="d_test-srcs"></a>srcs |  List of D '.d' or '.di' source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="d_test-imports"></a>imports |  List of import paths.   | List of strings | optional |  `[]`  |
+| <a id="d_test-string_imports"></a>string_imports |  List of string import paths.   | List of strings | optional |  `[]`  |
 | <a id="d_test-string_srcs"></a>string_srcs |  List of string import source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="d_test-versions"></a>versions |  List of version identifiers.   | List of strings | optional |  `[]`  |
 


### PR DESCRIPTION
This change introduces two new rule attributes, `imports` and `string_imports`, which make it possible to export interfaces from subdirectories.

This is particularly useful when consuming third-party packages that do not follow a Bazel-style file structure, allowing them to be integrated without restructuring their source tree.