### PR TITLE
fix: don't publish bcr PR as draft

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,6 +26,7 @@ jobs:
       tag_name: ${{ inputs.tag_name }}
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
       registry_fork: bazel-contrib/bazel-central-registry
+      draft: false
     permissions:
       attestations: write
       contents: write


### PR DESCRIPTION
This PR sets the `draft` parameter to `false` in the publish workflow, ensuring that pull requests opened in the [BCR repository](https://github.com/bazelbuild/bazel-central-registry) are not created as drafts.