### PR TITLE
fix: correct automatic release tagging delay to two weeks

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       new-tag: ${{ steps.ccv.outputs.new-tag }}
-      new-tag-version: ${{steps.ccv.outputs.new-tag-version}}
-      new-tag-version-type: ${{steps.ccv.outputs.new-tag-version-type}}
-      recently-tagged: ${{steps.recent-tag.outputs.recently-tagged}}
+      new-tag-version: ${{ steps.ccv.outputs.new-tag-version }}
+      new-tag-version-type: ${{ steps.ccv.outputs.new-tag-version-type }}
+      recently-tagged: ${{ steps.recent-tag.outputs.recently-tagged }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -47,7 +47,8 @@ jobs:
           fi
       - name: Bump tag if necessary
         id: ccv
-        uses: smlx/ccv@7318e2f25a52dcd550e75384b84983973251a1f8 # v0.10.0
+        if: github.event_name != 'schedule' || steps.recent-tag.outputs.recently-tagged != 'true'
+        uses: smlx/ccv@v0.10.0
   release:
     needs: tag
     uses: ./.github/workflows/release.yaml
@@ -55,7 +56,7 @@ jobs:
       tag_name: ${{ needs.tag.outputs.new-tag-version }}
     secrets:
       publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}
-    if: needs.tag.outputs.new-tag == 'true' && needs.tag.outputs.new-tag-version-type != 'major' && needs.tag.outputs.recently-tagged != 'true'
+    if: needs.tag.outputs.new-tag == 'true' && needs.tag.outputs.new-tag-version-type != 'major'
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Tag a release was bumping the version each day. Do this only every two weeks.