### PR TITLE
fix: add .bazelrc flag to support rules_cc >=0.2.14, update workspace…

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,8 @@ common --lockfile_mode=update
 
 # project-specific settings
 startup --windows_enable_symlinks
+# workaround for bazel8 error when --enable_workspace and --enable_bzlmod=false
+common --incompatible_autoload_externally=
 
 # Allows tests to run bazelisk-in-bazel, since this is the cache folder used
 common:ci --disk_cache=~/.cache/bazel

--- a/d/repositories.bzl
+++ b/d/repositories.bzl
@@ -31,9 +31,9 @@ def rules_d_dependencies():
     )
     http_archive(
         name = "package_metadata",
-        sha256 = "49ed11e5d6b752c55fa539cbb10b2736974f347b081d7bd500a80dacb7dbec06",
-        strip_prefix = "supply-chain-0.0.5/metadata",
-        url = "https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.5/supply-chain-v0.0.5.tar.gz",
+        sha256 = "5bd0cc7594ea528fd28f98d82457f157827d48cc20e07bcfdbb56072f35c8f67",
+        strip_prefix = "supply-chain-0.0.6/metadata",
+        url = "https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.6/supply-chain-v0.0.6.tar.gz",
     )
 
 ########

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -57,9 +57,9 @@ proto_bazel_features(name = "proto_bazel_features")
 
 http_archive(
     name = "rules_cc",
-    sha256 = "ae244f400218f4a12ee81658ff246c0be5cb02c5ca2de5519ed505a6795431e9",
-    strip_prefix = "rules_cc-0.2.0",
-    url = "https://github.com/bazelbuild/rules_cc/releases/download/0.2.0/rules_cc-0.2.0.tar.gz",
+    sha256 = "92fed78a5a310f86c060dcaed20f396ef0198cc3d46a46fdea7c469042cf02ce",
+    strip_prefix = "rules_cc-0.2.1",
+    url = "https://github.com/bazelbuild/rules_cc/releases/download/0.2.1/rules_cc-0.2.1.tar.gz",
 )
 
 load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")


### PR DESCRIPTION
- add .bazelrc flag to support rules_cc >=0.2.14
- update workspace package versions to match bzlmod versions