### PR TITLE
feat: add d_proto_library

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,8 @@ common:ci --lockfile_mode=update
 startup --windows_enable_symlinks
 # workaround for bazel8 error when --enable_workspace and --enable_bzlmod=false
 common --incompatible_autoload_externally=
+# BoringSSL currently fails under GCC 16's const-qualified memchr warning.
+common --per_file_copt=external/boringssl~/.+@-Wno-error=discarded-qualifiers
 
 # Keep the disk cache out of Bazel's own output base hierarchy.
 common:ci --disk_cache=~/.cache/bazel/disk_cache

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,6 +14,7 @@ bazel_dep(name = "boringssl", version = "0.20241209.0")  # Avoid compiler error 
 bazel_dep(name = "curl", version = "8.11.0.bcr.2")
 bazel_dep(name = "package_metadata", version = "0.0.6")
 bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "protobuf", version = "30.2")
 bazel_dep(name = "rules_cc", version = "0.2.1")
 
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.8.2", dev_dependency = True)
@@ -26,5 +27,8 @@ d = use_extension("//d:extensions.bzl", "d")
 d.toolchain(d_version = "dmd-2.112.0")
 d.toolchain(d_version = "ldc-1.41.0")
 use_repo(d, "d_toolchains")
+
+protobuf_d = use_extension("//d:extensions.bzl", "protobuf_d")
+use_repo(protobuf_d, "protobuf_d")
 
 register_toolchains("@d_toolchains//:all")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -240,7 +240,7 @@
   "moduleExtensions": {
     "//d:extensions.bzl%protobuf_d": {
       "general": {
-        "bzlTransitiveDigest": "DixnqP7eeyM5JtnVAQ6V9njMLnP1tlwVbKYet5nOMJQ=",
+        "bzlTransitiveDigest": "nnDcbNC+3MG3ddypeceZmkZyfVmahP+WHg9ZuXGqXPA=",
         "usagesDigest": "WZkd19+Smea+t678N9IvTHAtUEaxmn1sv7+yHEix6HM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -252,9 +252,9 @@
             "attributes": {
               "strip_prefix": "protobuf-d-0.7.0",
               "urls": [
-                "https://github.com/dcarp/protobuf-d/archive/refs/tags/v0.7.0.tar.gz"
+                "https://code.dlang.org/packages/protobuf/0.7.0.zip"
               ],
-              "integrity": "sha256-LM6v/r8kTNl58zvc1v8LHxPkKLYoVbKoXMornDxMfUg="
+              "integrity": "sha256-AKNEUJlnV4gheWFEEaq92dyzmy94HhCMjE9zgxoP/9I="
             }
           }
         },

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -10,10 +10,23 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/MODULE.bazel": "73939767a4686cd9a520d16af5ab440071ed75cec1a876bf2fcfaf1f71987a16",
-    "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/source.json": "750d5e29326fb59cbe61116a7b803c8a1d0a7090a9c8ed89888d188e3c473fc7",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250127.0/MODULE.bazel": "d1086e248cda6576862b4b3fe9ad76a214e08c189af5b42557a6e1888812c5d5",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250127.0/source.json": "1b996859f840d8efc7c720efc61dcf2a84b1261cb3974cbbe9b6666ebf567775",
+    "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
+    "https://bcr.bazel.build/modules/apple_support/1.13.0/MODULE.bazel": "7c8cdea7e031b7f9f67f0b497adf6d2c6a2675e9304ca93a9af6ed84eef5a524",
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
     "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
     "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.31.2/MODULE.bazel": "7bee702b4862612f29333590f4b658a5832d433d6f8e4395f090e8f4e85d442f",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "6307fec451ba9962c1c969eb516ebfe1e46528f7fa92e1c9ac8646bef4cdaa3f",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/MODULE.bazel": "668e6bcb4d957fc0e284316dba546b705c8d43c857f87119619ee83c4555b859",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/source.json": "f5a28b1320e5f444e798b4afc1465c8b720bfaec7522cca38a23583dffe85e6d",
+    "https://bcr.bazel.build/modules/aspect_rules_js/1.33.1/MODULE.bazel": "db3e7f16e471cf6827059d03af7c21859e7a0d2bc65429a3a11f005d46fc501b",
+    "https://bcr.bazel.build/modules/aspect_rules_js/1.39.0/MODULE.bazel": "aece421d479e3c31dc3e5f6d49a12acc2700457c03c556650ec7a0ff23fc0d95",
+    "https://bcr.bazel.build/modules/aspect_rules_js/1.39.0/source.json": "a8f93e4ad8843e8aa407fa5fd7c8b63a63846c0ce255371ff23384582813b13d",
+    "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/MODULE.bazel": "e767c5dbfeb254ec03275a7701b5cfde2c4d2873676804bc7cb27ddff3728fed",
+    "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/source.json": "9a3668e1ee219170e22c0e7f3ab959724c6198fdd12cd503fa10b1c6923a2559",
+    "https://bcr.bazel.build/modules/bazel_features/0.1.0/MODULE.bazel": "47011d645b0f949f42ee67f2e8775188a9cf4a0a1528aa2fa4952f2fd00906fd",
     "https://bcr.bazel.build/modules/bazel_features/1.0.0/MODULE.bazel": "d7f022dc887efb96e1ee51cec7b2e48d41e36ff59a6e4f216c40e4029e1585bf",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
@@ -22,8 +35,11 @@
     "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
+    "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
+    "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
     "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
+    "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
     "https://bcr.bazel.build/modules/bazel_features/1.32.0/MODULE.bazel": "095d67022a58cb20f7e20e1aefecfa65257a222c18a938e2914fd257b5f1ccdc",
     "https://bcr.bazel.build/modules/bazel_features/1.32.0/source.json": "2546c766986a6541f0bacd3e8542a1f621e2b14a80ea9e88c6f89f7eedf64ae1",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
@@ -56,6 +72,8 @@
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/curl/8.11.0.bcr.2/MODULE.bazel": "1125faea899f8c260adc9da78316c3c6dc8692aca6bd719096de7c7d16404cda",
     "https://bcr.bazel.build/modules/curl/8.11.0.bcr.2/source.json": "0a236372a12646df2b59436370e0fdb55d213bf69e585cf0dcd26aa8312577b2",
+    "https://bcr.bazel.build/modules/gazelle/0.27.0/MODULE.bazel": "3446abd608295de6d90b4a8a118ed64a9ce11dcb3dda2dc3290a22056bd20996",
+    "https://bcr.bazel.build/modules/gazelle/0.30.0/MODULE.bazel": "f888a1effe338491f35f0e0e85003b47bb9d8295ccba73c37e07702d8d31c65b",
     "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",
     "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
     "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
@@ -70,10 +88,13 @@
     "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
     "https://bcr.bazel.build/modules/googletest/1.15.2/source.json": "dbdda654dcb3a0d7a8bc5d0ac5fc7e150b58c2a986025ae5bc634bb2cb61f470",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
-    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
     "https://bcr.bazel.build/modules/mbedtls/3.6.0/MODULE.bazel": "8e380e4698107c5f8766264d4df92e36766248447858db28187151d884995a09",
     "https://bcr.bazel.build/modules/mbedtls/3.6.0/source.json": "1dbe7eb5258050afcc3806b9d43050f71c6f539ce0175535c670df606790b30c",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/source.json": "f448c6e8963fdfa7eb831457df83ad63d3d6355018f6574fb017e8169deb43a9",
     "https://bcr.bazel.build/modules/openssl/3.3.1.bcr.1/MODULE.bazel": "49c0c07e8fb87b480bccb842cfee1b32617f11dac590f732573c69058699a3d1",
     "https://bcr.bazel.build/modules/openssl/3.3.1.bcr.1/source.json": "0c0872e048bbea052a9c541fb47019481a19201ba5555a71d762ad591bf94e1f",
     "https://bcr.bazel.build/modules/package_metadata/0.0.5/MODULE.bazel": "ef4f9439e3270fdd6b9fd4dbc3d2f29d13888e44c529a1b243f7a31dfbc2e8e4",
@@ -93,10 +114,13 @@
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
     "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2.bcr.1/MODULE.bazel": "52f4126f63a2f0bbf36b99c2a87648f08467a4eaf92ba726bc7d6a500bbf770c",
-    "https://bcr.bazel.build/modules/protobuf/29.0-rc2.bcr.1/source.json": "cfbee3381201f20e35c304041b4abb3b793e66c9b1829b5478d033ad4a5e3aef",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
     "https://bcr.bazel.build/modules/protobuf/3.19.2/MODULE.bazel": "532ffe5f2186b69fdde039efe6df13ba726ff338c6bc82275ad433013fa10573",
     "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
+    "https://bcr.bazel.build/modules/protobuf/30.2/MODULE.bazel": "6b8b37f8390fbaf9bee5eed558697238082fab658a8a8996328628292ae79d2e",
+    "https://bcr.bazel.build/modules/protobuf/30.2/source.json": "7d7f541c637b49edbefa5aeca2cc365f2e3edac8d75fedb448d68ea003d9ded7",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
@@ -105,11 +129,16 @@
     "https://bcr.bazel.build/modules/re2/2024-07-02/source.json": "547d0111a9d4f362db32196fef805abbf3676e8d6afbe44d395d87816c1130ca",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
+    "https://bcr.bazel.build/modules/rules_apple/3.13.0/MODULE.bazel": "b4559a2c6281ca3165275bb36c1f0ac74666632adc5bdb680e366de7ce845f43",
+    "https://bcr.bazel.build/modules/rules_apple/3.13.0/source.json": "fe31c678e2256daa91a802664b578c1de71dc43a49a7ccc16db001378f312cd3",
+    "https://bcr.bazel.build/modules/rules_buf/0.1.1/MODULE.bazel": "6189aec18a4f7caff599ad41b851ab7645d4f1e114aa6431acf9b0666eb92162",
+    "https://bcr.bazel.build/modules/rules_buf/0.1.1/source.json": "021363d254f7438f3f10725355969c974bb2c67e0c28667782ade31a9cdb747f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.11/MODULE.bazel": "9f249c5624a4788067b96b8b896be10c7e8b4375dc46f6d8e1e51100113e0992",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
     "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
     "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
@@ -122,6 +151,9 @@
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
+    "https://bcr.bazel.build/modules/rules_go/0.33.0/MODULE.bazel": "a2b11b64cd24bf94f57454f53288a5dacfe6cb86453eee7761b7637728c1910c",
+    "https://bcr.bazel.build/modules/rules_go/0.38.1/MODULE.bazel": "fb8e73dd3b6fc4ff9d260ceacd830114891d49904f5bda1c16bc147bcc254f71",
+    "https://bcr.bazel.build/modules/rules_go/0.39.1/MODULE.bazel": "d34fb2a249403a5f4339c754f1e63dc9e5ad70b47c5e97faee1441fc6636cd61",
     "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
     "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
     "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
@@ -135,10 +167,13 @@
     "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
     "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
     "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
-    "https://bcr.bazel.build/modules/rules_java/7.12.2/source.json": "b0890f9cda8ff1b8e691a3ac6037b5c14b7fd4134765a3946b89f31ea02e5884",
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
     "https://bcr.bazel.build/modules/rules_java/7.6.5/MODULE.bazel": "481164be5e02e4cab6e77a36927683263be56b7e36fef918b458d7a8a1ebadb1",
+    "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
+    "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/source.json": "f18d9ad3c4c54945bf422ad584fa6c5ca5b3116ff55a5b1bc77e5c1210be5960",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -148,8 +183,11 @@
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
     "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
     "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
+    "https://bcr.bazel.build/modules/rules_license/0.0.8/MODULE.bazel": "5669c6fe49b5134dbf534db681ad3d67a2d49cfc197e4a95f1ca2fd7f3aebe96",
     "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
     "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
+    "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/MODULE.bazel": "6bc03c8f37f69401b888023bf511cb6ee4781433b0cb56236b2e55a21e3a026a",
+    "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/source.json": "6e82cf5753d835ea18308200bc79b9c2e782efe2e2a4edc004a9162ca93382ca",
     "https://bcr.bazel.build/modules/rules_perl/0.2.4/MODULE.bazel": "5f5af7be4bf5fb88d91af7469518f0fd2161718aefc606188f7cd51f436ca938",
     "https://bcr.bazel.build/modules/rules_perl/0.2.4/source.json": "574317d6b3c7e4843fe611b76f15e62a1889949f5570702e1ee4ad335ea3c339",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
@@ -169,24 +207,499 @@
     "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
     "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
     "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
-    "https://bcr.bazel.build/modules/rules_python/0.33.2/source.json": "e539592cd3aae4492032cecea510e46ca16eeb972271560b922cae9893944e2f",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/rules_python/1.0.0/MODULE.bazel": "898a3d999c22caa585eb062b600f88654bf92efb204fa346fb55f6f8edffca43",
+    "https://bcr.bazel.build/modules/rules_python/1.0.0/source.json": "b0162a65c6312e45e7912e39abd1a7f8856c2c7e41ecc9b6dc688a6f6400a917",
+    "https://bcr.bazel.build/modules/rules_rust/0.51.0/MODULE.bazel": "2b6d1617ac8503bfdcc0e4520c20539d4bba3a691100bee01afe193ceb0310f9",
+    "https://bcr.bazel.build/modules/rules_rust/0.51.0/source.json": "79a530199d9826a93b31d05b7d9b39dc753a80f88856d3ca5376f665a82cc5e6",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
     "https://bcr.bazel.build/modules/rules_shell/0.4.1/MODULE.bazel": "00e501db01bbf4e3e1dd1595959092c2fadf2087b2852d3f553b5370f5633592",
     "https://bcr.bazel.build/modules/rules_shell/0.4.1/source.json": "4757bd277fe1567763991c4425b483477bb82e35e777a56fd846eb5cceda324a",
+    "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
+    "https://bcr.bazel.build/modules/rules_swift/2.1.1/MODULE.bazel": "494900a80f944fc7aa61500c2073d9729dff0b764f0e89b824eb746959bc1046",
+    "https://bcr.bazel.build/modules/rules_swift/2.1.1/source.json": "40fc69dfaac64deddbb75bd99cdac55f4427d9ca0afbe408576a65428427a186",
+    "https://bcr.bazel.build/modules/stardoc/0.5.0/MODULE.bazel": "f9f1f46ba8d9c3362648eea571c6f9100680efc44913618811b58cc9c02cd678",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
+    "https://bcr.bazel.build/modules/stardoc/0.5.4/MODULE.bazel": "6569966df04610b8520957cb8e97cf2e9faac2c0309657c537ab51c16c18a2a4",
     "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
+    "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/source.json": "32bd87e5f4d7acc57c5b2ff7c325ae3061d5e242c0c4c214ae87e0f1c13e54cb",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "//d:extensions.bzl%protobuf_d": {
+      "general": {
+        "bzlTransitiveDigest": "DixnqP7eeyM5JtnVAQ6V9njMLnP1tlwVbKYet5nOMJQ=",
+        "usagesDigest": "WZkd19+Smea+t678N9IvTHAtUEaxmn1sv7+yHEix6HM=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "protobuf_d": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "strip_prefix": "protobuf-d-0.7.0",
+              "urls": [
+                "https://github.com/dcarp/protobuf-d/archive/refs/tags/v0.7.0.tar.gz"
+              ],
+              "integrity": "sha256-LM6v/r8kTNl58zvc1v8LHxPkKLYoVbKoXMornDxMfUg="
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@aspect_bazel_lib~//lib:extensions.bzl%toolchains": {
+      "general": {
+        "bzlTransitiveDigest": "a8tWABvj0Atq3WKbFAzcdfrByxB6/D+I6P+NXTkvIjE=",
+        "usagesDigest": "2yV4A8xZ6FZbGGe74q8xCktC2QFZ9qOJZI8VbIbhxtE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "copy_directory_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_directory_toolchain.bzl",
+            "ruleClassName": "copy_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "copy_directory_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_directory_toolchain.bzl",
+            "ruleClassName": "copy_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "copy_directory_freebsd_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_directory_toolchain.bzl",
+            "ruleClassName": "copy_directory_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "copy_directory_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_directory_toolchain.bzl",
+            "ruleClassName": "copy_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "copy_directory_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_directory_toolchain.bzl",
+            "ruleClassName": "copy_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "copy_directory_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_directory_toolchain.bzl",
+            "ruleClassName": "copy_directory_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "copy_directory_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_directory_toolchain.bzl",
+            "ruleClassName": "copy_directory_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "copy_directory"
+            }
+          },
+          "copy_to_directory_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "copy_to_directory_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "copy_to_directory_freebsd_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "copy_to_directory_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "copy_to_directory_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "copy_to_directory_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "copy_to_directory_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "copy_to_directory"
+            }
+          },
+          "jq_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "1.6"
+            }
+          },
+          "jq_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "1.6"
+            }
+          },
+          "jq_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "1.6"
+            }
+          },
+          "jq_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "1.6"
+            }
+          },
+          "jq": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_host_alias_repo",
+            "attributes": {}
+          },
+          "jq_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "jq"
+            }
+          },
+          "yq_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_s390x": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "linux_s390x",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_ppc64le": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "linux_ppc64le",
+              "version": "4.25.2"
+            }
+          },
+          "yq_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_host_alias_repo",
+            "attributes": {}
+          },
+          "yq_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:yq_toolchain.bzl",
+            "ruleClassName": "yq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "yq"
+            }
+          },
+          "coreutils_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "coreutils"
+            }
+          },
+          "expand_template_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:expand_template_toolchain.bzl",
+            "ruleClassName": "expand_template_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "expand_template_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:expand_template_toolchain.bzl",
+            "ruleClassName": "expand_template_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "expand_template_freebsd_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:expand_template_toolchain.bzl",
+            "ruleClassName": "expand_template_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "expand_template_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:expand_template_toolchain.bzl",
+            "ruleClassName": "expand_template_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "expand_template_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:expand_template_toolchain.bzl",
+            "ruleClassName": "expand_template_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "expand_template_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:expand_template_toolchain.bzl",
+            "ruleClassName": "expand_template_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "expand_template_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:expand_template_toolchain.bzl",
+            "ruleClassName": "expand_template_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "expand_template"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_bazel_lib~",
+            "aspect_bazel_lib",
+            "aspect_bazel_lib~"
+          ],
+          [
+            "aspect_bazel_lib~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "aspect_bazel_lib~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@aspect_rules_js~//npm:extensions.bzl%pnpm": {
+      "general": {
+        "bzlTransitiveDigest": "bPSeAjiLncSh+DG56r1X7EdBnElPs2TDO1jpPgRGfiU=",
+        "usagesDigest": "1hU324o/rWis1wprOwPM+3YiIXklZvJ5jfmEbzKAClo=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "pnpm": {
+            "bzlFile": "@@aspect_rules_js~//npm/private:npm_import.bzl",
+            "ruleClassName": "npm_import_rule",
+            "attributes": {
+              "package": "pnpm",
+              "version": "8.6.7",
+              "root_package": "",
+              "link_workspace": "",
+              "link_packages": {},
+              "integrity": "sha512-vRIWpD/L4phf9Bk2o/O2TDR8fFoJnpYrp2TKqTIZF/qZ2/rgL3qKXzHofHgbXsinwMoSEigz28sqk3pQ+yMEQQ==",
+              "url": "",
+              "commit": "",
+              "patch_args": [
+                "-p0"
+              ],
+              "patches": [],
+              "custom_postinstall": "",
+              "npm_auth": "",
+              "npm_auth_basic": "",
+              "npm_auth_username": "",
+              "npm_auth_password": "",
+              "lifecycle_hooks": [],
+              "extra_build_content": "load(\"@aspect_rules_js//js:defs.bzl\", \"js_binary\")\njs_binary(name = \"pnpm\", data = glob([\"package/**\"]), entry_point = \"package/dist/pnpm.cjs\", visibility = [\"//visibility:public\"])",
+              "generate_bzl_library_targets": false
+            }
+          },
+          "pnpm__links": {
+            "bzlFile": "@@aspect_rules_js~//npm/private:npm_import.bzl",
+            "ruleClassName": "npm_import_links",
+            "attributes": {
+              "package": "pnpm",
+              "version": "8.6.7",
+              "dev": false,
+              "root_package": "",
+              "link_packages": {},
+              "deps": {},
+              "transitive_closure": {},
+              "lifecycle_build_target": false,
+              "lifecycle_hooks_env": [],
+              "lifecycle_hooks_execution_requirements": [
+                "no-sandbox"
+              ],
+              "lifecycle_hooks_use_default_shell_env": false,
+              "bins": {},
+              "npm_translate_lock_repo": "",
+              "package_visibility": [
+                "//visibility:public"
+              ],
+              "replace_package": ""
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_bazel_lib~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "aspect_bazel_lib~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "aspect_rules_js~",
+            "aspect_bazel_lib",
+            "aspect_bazel_lib~"
+          ],
+          [
+            "aspect_rules_js~",
+            "bazel_features",
+            "bazel_features~"
+          ],
+          [
+            "aspect_rules_js~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "aspect_rules_js~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "bazel_features~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@pybind11_bazel~//:internal_configure.bzl%internal_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "ITysE3qT9ee8ipAmrQmkGImmq2UkzlEY/ZI2L3+wmI8=",
@@ -212,6 +725,133 @@
         "recordedRepoMappingEntries": [
           [
             "pybind11_bazel~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_apple~//apple:apple.bzl%provisioning_profile_repository_extension": {
+      "general": {
+        "bzlTransitiveDigest": "y8YI/N5WIZPBvCv6NN3U0t2dv5tzXMwL/U/67WmMP+E=",
+        "usagesDigest": "mXR1UQCCawtbr4R17Kq15cl6tn2XTMsIyKBsJe+yv7o=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_provisioning_profiles": {
+            "bzlFile": "@@rules_apple~//apple/internal:local_provisioning_profiles.bzl",
+            "ruleClassName": "provisioning_profile_repository",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "apple_support~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "rules_apple~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "rules_apple~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_apple~",
+            "build_bazel_apple_support",
+            "apple_support~"
+          ],
+          [
+            "rules_apple~",
+            "build_bazel_rules_apple",
+            "rules_apple~"
+          ],
+          [
+            "rules_apple~",
+            "build_bazel_rules_swift",
+            "rules_swift~"
+          ],
+          [
+            "rules_swift~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "rules_swift~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_swift~",
+            "build_bazel_apple_support",
+            "apple_support~"
+          ],
+          [
+            "rules_swift~",
+            "build_bazel_rules_swift",
+            "rules_swift~"
+          ],
+          [
+            "rules_swift~",
+            "build_bazel_rules_swift_local_config",
+            "rules_swift~~non_module_deps~build_bazel_rules_swift_local_config"
+          ]
+        ]
+      }
+    },
+    "@@rules_apple~//apple:extensions.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "Ia8tEfgBgcPGg7pBbN19ry75D46ClFYPRisPOZv5Ex8=",
+        "usagesDigest": "COjTlExcyFNMflFhPONwglOyzEttXJwg5sY2revlmX4=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "xctestrunner": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/google/xctestrunner/archive/b7698df3d435b6491b4b4c0f9fc7a63fbed5e3a6.tar.gz"
+              ],
+              "strip_prefix": "xctestrunner-b7698df3d435b6491b4b4c0f9fc7a63fbed5e3a6",
+              "sha256": "ae3a063c985a8633cb7eb566db21656f8db8eb9a0edb8c182312c7f0db53730d"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_apple~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_buf~//buf:extensions.bzl%ext": {
+      "general": {
+        "bzlTransitiveDigest": "jKgc1jSOhAhYgT4nrSMRKyIUYRDloBY88yoEhl/lVOY=",
+        "usagesDigest": "1E3NeLCRI6VyKiersXVtONCbNopc5jIVqoHBOpcWb0A=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rules_buf_toolchains": {
+            "bzlFile": "@@rules_buf~//buf/internal:toolchain.bzl",
+            "ruleClassName": "buf_download_releases",
+            "attributes": {
+              "version": "v1.27.0"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_buf~",
             "bazel_tools",
             "bazel_tools"
           ]
@@ -309,6 +949,29 @@
         ]
       }
     },
+    "@@rules_java~//java:rules_java_deps.bzl%compatibility_proxy": {
+      "general": {
+        "bzlTransitiveDigest": "wz/gaA3xHNx01lt9KMTpLRTOGQHRWnTsAPhRfjdk21k=",
+        "usagesDigest": "I6+CGVbSrNp2QwSmF31WrXKCF4JkXIiGHgmLdJ7jzeQ=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "compatibility_proxy": {
+            "bzlFile": "@@rules_java~//java:rules_java_deps.bzl",
+            "ruleClassName": "_compatibility_proxy_repo_rule",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_java~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_kotlin~//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "eecmTsmdIQveoA97hPtH3/Ej/kugbdCI24bhXIXaly8=",
@@ -372,6 +1035,106 @@
         "recordedRepoMappingEntries": [
           [
             "rules_kotlin~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_nodejs~//nodejs:extensions.bzl%node": {
+      "general": {
+        "bzlTransitiveDigest": "WTejgpQLmveuk8NmKNiMlxfph3GLP0tSlD0CBOIpuZA=",
+        "usagesDigest": "9IUJvk13jWE1kE+N3sP2y0mw9exjO9CGQ2oAgwKTNK4=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "nodejs_linux_amd64": {
+            "bzlFile": "@@rules_nodejs~//nodejs:repositories.bzl",
+            "ruleClassName": "node_repositories",
+            "attributes": {
+              "platform": "linux_amd64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_linux_arm64": {
+            "bzlFile": "@@rules_nodejs~//nodejs:repositories.bzl",
+            "ruleClassName": "node_repositories",
+            "attributes": {
+              "platform": "linux_arm64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_linux_s390x": {
+            "bzlFile": "@@rules_nodejs~//nodejs:repositories.bzl",
+            "ruleClassName": "node_repositories",
+            "attributes": {
+              "platform": "linux_s390x",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_linux_ppc64le": {
+            "bzlFile": "@@rules_nodejs~//nodejs:repositories.bzl",
+            "ruleClassName": "node_repositories",
+            "attributes": {
+              "platform": "linux_ppc64le",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_darwin_amd64": {
+            "bzlFile": "@@rules_nodejs~//nodejs:repositories.bzl",
+            "ruleClassName": "node_repositories",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_darwin_arm64": {
+            "bzlFile": "@@rules_nodejs~//nodejs:repositories.bzl",
+            "ruleClassName": "node_repositories",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_windows_amd64": {
+            "bzlFile": "@@rules_nodejs~//nodejs:repositories.bzl",
+            "ruleClassName": "node_repositories",
+            "attributes": {
+              "platform": "windows_amd64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs": {
+            "bzlFile": "@@rules_nodejs~//nodejs/private:nodejs_repo_host_os_alias.bzl",
+            "ruleClassName": "nodejs_repo_host_os_alias",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          },
+          "nodejs_host": {
+            "bzlFile": "@@rules_nodejs~//nodejs/private:nodejs_repo_host_os_alias.bzl",
+            "ruleClassName": "nodejs_repo_host_os_alias",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          },
+          "nodejs_toolchains": {
+            "bzlFile": "@@rules_nodejs~//nodejs/private:toolchains_repo.bzl",
+            "ruleClassName": "toolchains_repo",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_nodejs~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "rules_nodejs~",
             "bazel_tools",
             "bazel_tools"
           ]
@@ -457,2254 +1220,2611 @@
         ]
       }
     },
-    "@@rules_python~//python/private/bzlmod:pip.bzl%pip_internal": {
+    "@@rules_python~//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "a/wZuUHe4MaN4z3M4N/HYrAezmGZKjKavsn4DQ0HOOY=",
-        "usagesDigest": "Ytl7Xydpzlx/9E3VePX4x952J6xMN3xDnNsv/9gX+Zw=",
+        "bzlTransitiveDigest": "0XPJSLdAWtBXXwzGKWU9FgSeU5uSrp0wq+InSqDroeA=",
+        "usagesDigest": "jk2xiyIApibIAPn4+J6E7mGcedb5aCzVHf4I1ZrZkbA=",
         "recordedFileInputs": {
-          "@@rules_python~//tools/publish/requirements.txt": "8ced1e640eab3ee44298590e5ad88cd612f5bf96245af1981709f7a8884a982b",
-          "@@rules_python~//tools/publish/requirements_windows.txt": "0b7327c4f5751dc429bf53d21fc0797a7a0a6ac468ddcb38e238bed90ef0a7da",
-          "@@rules_python~//tools/publish/requirements_darwin.txt": "a29d72a09b755c284377ca1bb4ae1bea27ef8b01d575b40e21a777e53b513381"
+          "@@rules_python~//tools/publish/requirements_linux.txt": "8175b4c8df50ae2f22d1706961884beeb54e7da27bd2447018314a175981997d",
+          "@@rules_fuzzing~//fuzzing/requirements.txt": "ab04664be026b632a0d2a2446c4f65982b7654f5b6851d2f9d399a19b7242a5b",
+          "@@rules_python~//tools/publish/requirements_windows.txt": "7673adc71dc1a81d3661b90924d7a7c0fc998cd508b3cb4174337cef3f2de556",
+          "@@rules_python~//tools/publish/requirements_darwin.txt": "2994136eab7e57b083c3de76faf46f70fad130bc8e7360a7fed2b288b69e79dc"
         },
         "recordedDirentsInputs": {},
-        "envVariables": {},
+        "envVariables": {
+          "RULES_PYTHON_REPO_DEBUG": null,
+          "RULES_PYTHON_REPO_DEBUG_VERBOSITY": null
+        },
         "generatedRepoSpecs": {
-          "rules_python_publish_deps_311_six_py2_none_any_8abb2f1d": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_fuzzing_py_deps_310_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "rules_fuzzing_py_deps_310",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "rules_fuzzing_py_deps_310_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "rules_fuzzing_py_deps_310",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "rules_fuzzing_py_deps_311_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_fuzzing_py_deps_311",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "rules_fuzzing_py_deps_311_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_fuzzing_py_deps_311",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "rules_fuzzing_py_deps_312_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "rules_fuzzing_py_deps_312",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "rules_fuzzing_py_deps_312_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "rules_fuzzing_py_deps_312",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "rules_fuzzing_py_deps_38_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "rules_fuzzing_py_deps_38",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "rules_fuzzing_py_deps_38_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "rules_fuzzing_py_deps_38",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "rules_fuzzing_py_deps_39_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "rules_fuzzing_py_deps_39",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "rules_fuzzing_py_deps_39_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "rules_fuzzing_py_deps_39",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "rules_python_publish_deps_311_backports_tarfile_py3_none_any_77e284d7": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "six-1.16.0-py2.py3-none-any.whl",
-              "isolated": true,
+              "filename": "backports.tarfile-1.2.0-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "six==1.16.0",
-              "sha256": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
-              "timeout": 600,
+              "requirement": "backports-tarfile==1.2.0",
+              "sha256": "77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34",
               "urls": [
-                "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_six_sdist_1e61c374": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_backports_tarfile_sdist_d75e02c2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "six-1.16.0.tar.gz",
-              "isolated": true,
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "backports_tarfile-1.2.0.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "six==1.16.0",
-              "sha256": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-              "timeout": 600,
+              "requirement": "backports-tarfile==1.2.0",
+              "sha256": "d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991",
               "urls": [
-                "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
+                "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz"
               ]
             }
           },
-          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_aarch64_3548db28": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_certifi_py3_none_any_922820b5": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "isolated": true,
+              "filename": "certifi-2024.8.30-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.15.1",
-              "sha256": "3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c",
-              "timeout": 600,
+              "requirement": "certifi==2024.8.30",
+              "sha256": "922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
               "urls": [
-                "https://files.pythonhosted.org/packages/91/bc/b7723c2fe7a22eee71d7edf2102cd43423d5f95ff3932ebaa2f82c7ec8d0/cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+                "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_ppc64le_91fc98ad": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_certifi_sdist_bec941d2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
-              "isolated": true,
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "certifi-2024.8.30.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.15.1",
-              "sha256": "91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325",
-              "timeout": 600,
+              "requirement": "certifi==2024.8.30",
+              "sha256": "bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9",
               "urls": [
-                "https://files.pythonhosted.org/packages/5d/4e/4e0bb5579b01fdbfd4388bd1eb9394a989e1336203a4b7f700d887b233c1/cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+                "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz"
               ]
             }
           },
-          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_x86_64_94411f22": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_aarch64_a1ed2dd2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
               ],
-              "filename": "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "isolated": true,
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.15.1",
-              "sha256": "94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c",
-              "timeout": 600,
+              "requirement": "cffi==1.17.1",
+              "sha256": "a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41",
               "urls": [
-                "https://files.pythonhosted.org/packages/37/5a/c37631a86be838bdd84cc0259130942bf7e6e32f70f4cab95f479847fb91/cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+                "https://files.pythonhosted.org/packages/2e/ea/70ce63780f096e16ce8588efe039d3c4f91deb1dc01e9c73a287939c79a6/cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_x86_64_cc4d65ae": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_ppc64le_46bf4316": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
               ],
-              "filename": "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl",
-              "isolated": true,
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.15.1",
-              "sha256": "cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8",
-              "timeout": 600,
+              "requirement": "cffi==1.17.1",
+              "sha256": "46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1",
               "urls": [
-                "https://files.pythonhosted.org/packages/d3/56/3e94aa719ae96eeda8b68b3ec6e347e0a23168c6841dc276ccdcdadc9f32/cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+                "https://files.pythonhosted.org/packages/1c/a0/a4fa9f4f781bda074c3ddd57a572b060fa0df7655d2a4247bbe277200146/cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_cffi_sdist_d400bfb9": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_s390x_a24ed04c": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
               ],
-              "filename": "cffi-1.15.1.tar.gz",
-              "isolated": true,
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "cffi==1.15.1",
-              "sha256": "d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9",
-              "timeout": 600,
+              "requirement": "cffi==1.17.1",
+              "sha256": "a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6",
               "urls": [
-                "https://files.pythonhosted.org/packages/2b/a8/050ab4f0c3d4c1b8aaa805f70e26e84d0e27004907c5b8ecc1d31815f92a/cffi-1.15.1.tar.gz"
+                "https://files.pythonhosted.org/packages/62/12/ce8710b5b8affbcdd5c6e367217c242524ad17a02fe5beec3ee339f69f85/cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_idna_py3_none_any_90b77e79": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_x86_64_610faea7": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
               ],
-              "filename": "idna-3.4-py3-none-any.whl",
-              "isolated": true,
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "idna==3.4",
-              "sha256": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2",
-              "timeout": 600,
+              "requirement": "cffi==1.17.1",
+              "sha256": "610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d",
               "urls": [
-                "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/ff/6b/d45873c5e0242196f042d555526f92aa9e0c32355a1be1ff8c27f077fd37/cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_idna_sdist_814f528e": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_aarch64_a9b15d49": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
               ],
-              "filename": "idna-3.4.tar.gz",
-              "isolated": true,
+              "filename": "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "idna==3.4",
-              "sha256": "814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
-              "timeout": 600,
+              "requirement": "cffi==1.17.1",
+              "sha256": "a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6",
               "urls": [
-                "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz"
+                "https://files.pythonhosted.org/packages/1a/52/d9a0e523a572fbccf2955f5abe883cfa8bcc570d7faeee06336fbd50c9fc/cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_rich_py3_none_any_7c963f0d": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_x86_64_fc48c783": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
               ],
-              "filename": "rich-13.2.0-py3-none-any.whl",
-              "isolated": true,
+              "filename": "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "rich==13.2.0",
-              "sha256": "7c963f0d03819221e9ac561e1bc866e3f95a02248c1234daa48954e6d381c003",
-              "timeout": 600,
+              "requirement": "cffi==1.17.1",
+              "sha256": "fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b",
               "urls": [
-                "https://files.pythonhosted.org/packages/0e/cf/a6369a2aee266c2d7604230f083d4bd14b8f69bc69eb25b3da63b9f2f853/rich-13.2.0-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/f8/4a/34599cac7dfcd888ff54e801afe06a19c17787dfd94495ab0c8d35fe99fb/cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_rich_sdist_f1a00cdd": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_cffi_sdist_1c39c601": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
               ],
-              "filename": "rich-13.2.0.tar.gz",
-              "isolated": true,
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "cffi-1.17.1.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "rich==13.2.0",
-              "sha256": "f1a00cdd3eebf999a15d85ec498bfe0b1a77efe9b34f645768a54132ef444ac5",
-              "timeout": 600,
+              "requirement": "cffi==1.17.1",
+              "sha256": "1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824",
               "urls": [
-                "https://files.pythonhosted.org/packages/9e/5e/c3dc3ea32e2c14bfe46e48de954dd175bff76bcc549dd300acb9689521ae/rich-13.2.0.tar.gz"
+                "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz"
               ]
             }
           },
-          "rules_python_publish_deps_311_zipp_py3_none_any_83a28fcb": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_universal2_0d99dd8f": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "zipp-3.11.0-py3-none-any.whl",
-              "isolated": true,
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "zipp==3.11.0",
-              "sha256": "83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa",
-              "timeout": 600,
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "0d99dd8ff461990f12d6e42c7347fd9ab2532fb70e9621ba520f9e8637161d7c",
               "urls": [
-                "https://files.pythonhosted.org/packages/d8/20/256eb3f3f437c575fb1a2efdce5e801a5ce3162ea8117da96c43e6ee97d8/zipp-3.11.0-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/9c/61/73589dcc7a719582bf56aae309b6103d2762b526bffe189d635a7fcfd998/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_zipp_sdist_a7a22e05": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_x86_64_c57516e5": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "zipp-3.11.0.tar.gz",
-              "isolated": true,
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "zipp==3.11.0",
-              "sha256": "a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766",
-              "timeout": 600,
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944",
               "urls": [
-                "https://files.pythonhosted.org/packages/8e/b3/8b16a007184714f71157b1a71bbe632c5d66dd43bc8152b3c799b13881e1/zipp-3.11.0.tar.gz"
+                "https://files.pythonhosted.org/packages/77/d5/8c982d58144de49f59571f940e329ad6e8615e1e82ef84584c5eeb5e1d72/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_mdurl_py3_none_any_84008a41": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_11_0_arm64_6dba5d19": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "mdurl-0.1.2-py3-none-any.whl",
-              "isolated": true,
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "mdurl==0.1.2",
-              "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
-              "timeout": 600,
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee",
               "urls": [
-                "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/bf/19/411a64f01ee971bed3231111b69eb56f9331a769072de479eae7de52296d/charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_mdurl_sdist_bb413d29": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_aarch64_bf4475b8": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "mdurl-0.1.2.tar.gz",
-              "isolated": true,
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "mdurl==0.1.2",
-              "sha256": "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba",
-              "timeout": 600,
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "bf4475b82be41b07cc5e5ff94810e6a01f276e37c2d55571e3fe175e467a1a1c",
               "urls": [
-                "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+                "https://files.pythonhosted.org/packages/4c/92/97509850f0d00e9f14a46bc751daabd0ad7765cff29cdfb66c68b6dad57f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_twine_py3_none_any_929bc3c2": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_ppc64le_ce031db0": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "twine-4.0.2-py3-none-any.whl",
-              "isolated": true,
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "twine==4.0.2",
-              "sha256": "929bc3c280033347a00f847236564d1c52a3e61b1ac2516c97c48f3ceab756d8",
-              "timeout": 600,
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "ce031db0408e487fd2775d745ce30a7cd2923667cf3b69d48d219f1d8f5ddeb6",
               "urls": [
-                "https://files.pythonhosted.org/packages/3a/38/a3f27a9e8ce45523d7d1e28c09e9085b61a98dab15d35ec086f36a44b37c/twine-4.0.2-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/e2/29/d227805bff72ed6d6cb1ce08eec707f7cfbd9868044893617eb331f16295/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_twine_sdist_9e102ef5": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_s390x_8ff4e7cd": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "twine-4.0.2.tar.gz",
-              "isolated": true,
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "twine==4.0.2",
-              "sha256": "9e102ef5fdd5a20661eb88fad46338806c3bd32cf1db729603fe3697b1bc83c8",
-              "timeout": 600,
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "8ff4e7cdfdb1ab5698e675ca622e72d58a6fa2a8aa58195de0c0061288e6e3ea",
               "urls": [
-                "https://files.pythonhosted.org/packages/b7/1a/a7884359429d801cd63c2c5512ad0a337a509994b0e42d9696d4778d71f6/twine-4.0.2.tar.gz"
+                "https://files.pythonhosted.org/packages/13/bc/87c2c9f2c144bedfa62f894c3007cd4530ba4b5351acb10dc786428a50f0/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_bleach_py3_none_any_33c16e33": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_x86_64_3710a975": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "bleach-6.0.0-py3-none-any.whl",
-              "isolated": true,
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "bleach==6.0.0",
-              "sha256": "33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4",
-              "timeout": 600,
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "3710a9751938947e6327ea9f3ea6332a09bf0ba0c09cae9cb1f250bd1f1549bc",
               "urls": [
-                "https://files.pythonhosted.org/packages/ac/e2/dfcab68c9b2e7800c8f06b85c76e5f978d05b195a958daa9b1dda54a1db6/bleach-6.0.0-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/eb/5b/6f10bad0f6461fa272bfbbdf5d0023b5fb9bc6217c92bf068fa5a99820f5/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_bleach_sdist_1a1a85c1": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_aarch64_47334db7": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "bleach-6.0.0.tar.gz",
-              "isolated": true,
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "bleach==6.0.0",
-              "sha256": "1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414",
-              "timeout": 600,
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "47334db71978b23ebcf3c0f9f5ee98b8d65992b65c9c4f2d34c2eaf5bcaf0594",
               "urls": [
-                "https://files.pythonhosted.org/packages/7e/e6/d5f220ca638f6a25557a611860482cb6e54b2d97f0332966b1b005742e1f/bleach-6.0.0.tar.gz"
+                "https://files.pythonhosted.org/packages/d7/a1/493919799446464ed0299c8eef3c3fad0daf1c3cd48bff9263c731b0d9e2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_certifi_py3_none_any_4ad3232f": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_ppc64le_f1a2f519": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "certifi-2022.12.7-py3-none-any.whl",
-              "isolated": true,
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "certifi==2022.12.7",
-              "sha256": "4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18",
-              "timeout": 600,
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "f1a2f519ae173b5b6a2c9d5fa3116ce16e48b3462c8b96dfdded11055e3d6365",
               "urls": [
-                "https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/75/d2/0ab54463d3410709c09266dfb416d032a08f97fd7d60e94b8c6ef54ae14b/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_certifi_sdist_35824b4c": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_s390x_63bc5c4a": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "certifi-2022.12.7.tar.gz",
-              "isolated": true,
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "certifi==2022.12.7",
-              "sha256": "35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
-              "timeout": 600,
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "63bc5c4ae26e4bc6be6469943b8253c0fd4e4186c43ad46e713ea61a0ba49129",
               "urls": [
-                "https://files.pythonhosted.org/packages/37/f7/2b1b0ec44fdc30a3d31dfebe52226be9ddc40cd6c0f34ffc8923ba423b69/certifi-2022.12.7.tar.gz"
+                "https://files.pythonhosted.org/packages/8d/c9/27e41d481557be53d51e60750b85aa40eaf52b841946b3cdeff363105737/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_certifi_py3_none_any_92d60375": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_x86_64_bcb4f8ea": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "certifi-2023.7.22-py3-none-any.whl",
-              "isolated": true,
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "certifi==2023.7.22",
-              "sha256": "92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9",
-              "timeout": 600,
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "bcb4f8ea87d03bc51ad04add8ceaf9b0f085ac045ab4d74e73bbc2dc033f0236",
               "urls": [
-                "https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/ee/44/4f62042ca8cdc0cabf87c0fc00ae27cd8b53ab68be3605ba6d071f742ad3/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_certifi_sdist_539cc1d1": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_win_amd64_cee4373f": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "certifi-2023.7.22.tar.gz",
-              "isolated": true,
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "certifi==2023.7.22",
-              "sha256": "539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082",
-              "timeout": 600,
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "cee4373f4d3ad28f1ab6290684d8e2ebdb9e7a1b74fdc39e4c211995f77bec27",
               "urls": [
-                "https://files.pythonhosted.org/packages/98/98/c2ff18671db109c9f10ed27f5ef610ae05b73bd876664139cf95bd1429aa/certifi-2023.7.22.tar.gz"
+                "https://files.pythonhosted.org/packages/0b/6e/b13bd47fa9023b3699e94abf565b5a2f0b0be6e9ddac9812182596ee62e4/charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_py3_none_any_fe9f97fe": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079",
+              "urls": [
+                "https://files.pythonhosted.org/packages/bf/9b/08c0432272d77b04803958a4598a51e2a4b51c06640af8b8f0f908c18bf2/charset_normalizer-3.4.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_sdist_223217c3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "charset_normalizer-3.4.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_aarch64_846da004": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "846da004a5804145a5f441b8530b4bf35afbf7da70f82409f151695b127213d5",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2f/78/55356eb9075d0be6e81b59f45c7b48df87f76a20e73893872170471f3ee8/cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_x86_64_0f996e72": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "0f996e7268af62598f2fc1204afa98a3b5712313a55c4c9d434aef49cadc91d4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2a/2c/488776a3dc843f95f86d2f957ca0fc3407d0242b50bede7fad1e339be03f/cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_aarch64_f7b178f1": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "f7b178f11ed3664fd0e995a47ed2b5ff0a12d893e41dd0494f406d1cf555cab7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7c/04/2345ca92f7a22f601a9c62961741ef7dd0127c39f7310dffa0041c80f16f/cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_x86_64_c2e6fc39": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "c2e6fc39c4ab499049df3bdf567f768a723a5e8464816e8f009f121a5a9f4405",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ac/25/e715fa0bc24ac2114ed69da33adf451a38abb6f3f24ec207908112e9ba53/cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_aarch64_e1be4655": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "e1be4655c7ef6e1bbe6b5d0403526601323420bcf414598955968c9ef3eb7d16",
+              "urls": [
+                "https://files.pythonhosted.org/packages/21/ce/b9c9ff56c7164d8e2edfb6c9305045fbc0df4508ccfdb13ee66eb8c95b0e/cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_x86_64_df6b6c6d": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "df6b6c6d742395dd77a23ea3728ab62f98379eff8fb61be2744d4679ab678f73",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2a/33/b3682992ab2e9476b9c81fff22f02c8b0a1e6e1d49ee1750a67d85fd7ed2/cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_sdist_315b9001": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "cryptography-43.0.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805",
+              "urls": [
+                "https://files.pythonhosted.org/packages/0d/05/07b55d1fa21ac18c3a8c79f764e2514e6f6a9698f1be44994f5adf0d29db/cryptography-43.0.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_docutils_py3_none_any_dafca5b9": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "docutils-0.21.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "docutils==0.21.2",
+              "sha256": "dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_docutils_sdist_3a6b1873": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "docutils-0.21.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "docutils==0.21.2",
+              "sha256": "3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_idna_py3_none_any_946d195a": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "idna-3.10-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "idna==3.10",
+              "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_idna_sdist_12f65c9b": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "idna-3.10.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "idna==3.10",
+              "sha256": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_importlib_metadata_py3_none_any_45e54197": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "importlib_metadata-8.5.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "importlib-metadata==8.5.0",
+              "sha256": "45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a0/d9/a1e041c5e7caa9a05c925f4bdbdfb7f006d1f74996af53467bc394c97be7/importlib_metadata-8.5.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_importlib_metadata_sdist_71522656": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "importlib_metadata-8.5.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "importlib-metadata==8.5.0",
+              "sha256": "71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_classes_py3_none_any_f662826b": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.classes-3.4.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-classes==3.4.0",
+              "sha256": "f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_classes_sdist_47a024b5": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "jaraco.classes-3.4.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-classes==3.4.0",
+              "sha256": "47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd",
+              "urls": [
+                "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_context_py3_none_any_f797fc48": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.context-6.0.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-context==6.0.1",
+              "sha256": "f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_context_sdist_9bae4ea5": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "jaraco_context-6.0.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-context==6.0.1",
+              "sha256": "9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_functools_py3_none_any_ad159f13": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.functools-4.1.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-functools==4.1.0",
+              "sha256": "ad159f13428bc4acbf5541ad6dec511f91573b90fba04df61dafa2a1231cf649",
+              "urls": [
+                "https://files.pythonhosted.org/packages/9f/4f/24b319316142c44283d7540e76c7b5a6dbd5db623abd86bb7b3491c21018/jaraco.functools-4.1.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_functools_sdist_70f7e0e2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "jaraco_functools-4.1.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-functools==4.1.0",
+              "sha256": "70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz"
               ]
             }
           },
           "rules_python_publish_deps_311_jeepney_py3_none_any_c0a454ad": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
               ],
               "filename": "jeepney-0.8.0-py3-none-any.whl",
-              "isolated": true,
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
               "requirement": "jeepney==0.8.0",
               "sha256": "c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755",
-              "timeout": 600,
               "urls": [
                 "https://files.pythonhosted.org/packages/ae/72/2a1e2290f1ab1e06f71f3d0f1646c9e4634e70e1d37491535e19266e8dc9/jeepney-0.8.0-py3-none-any.whl"
               ]
             }
           },
           "rules_python_publish_deps_311_jeepney_sdist_5efe48d2": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
               ],
               "filename": "jeepney-0.8.0.tar.gz",
-              "isolated": true,
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
               "requirement": "jeepney==0.8.0",
               "sha256": "5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806",
-              "timeout": 600,
               "urls": [
                 "https://files.pythonhosted.org/packages/d6/f4/154cf374c2daf2020e05c3c6a03c91348d59b23c5366e968feb198306fdf/jeepney-0.8.0.tar.gz"
               ]
             }
           },
-          "rules_python_publish_deps_311_keyring_py3_none_any_771ed2a9": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_keyring_py3_none_any_5426f817": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "keyring-23.13.1-py3-none-any.whl",
-              "isolated": true,
+              "filename": "keyring-25.4.1-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "keyring==23.13.1",
-              "sha256": "771ed2a91909389ed6148631de678f82ddc73737d85a927f382a8a1b157898cd",
-              "timeout": 600,
+              "requirement": "keyring==25.4.1",
+              "sha256": "5426f817cf7f6f007ba5ec722b1bcad95a75b27d780343772ad76b17cb47b0bf",
               "urls": [
-                "https://files.pythonhosted.org/packages/62/db/0e9a09b2b95986dcd73ac78be6ed2bd73ebe8bac65cba7add5b83eb9d899/keyring-23.13.1-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/83/25/e6d59e5f0a0508d0dca8bb98c7f7fd3772fc943ac3f53d5ab18a218d32c0/keyring-25.4.1-py3-none-any.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_keyring_sdist_ba2e15a9": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_keyring_sdist_b07ebc55": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "keyring-23.13.1.tar.gz",
-              "isolated": true,
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "keyring-25.4.1.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "keyring==23.13.1",
-              "sha256": "ba2e15a9b35e21908d0aaf4e0a47acc52d6ae33444df0da2b49d41a46ef6d678",
-              "timeout": 600,
+              "requirement": "keyring==25.4.1",
+              "sha256": "b07ebc55f3e8ed86ac81dd31ef14e81ace9dd9c3d4b5d77a6e9a2016d0d71a1b",
               "urls": [
-                "https://files.pythonhosted.org/packages/55/fe/282f4c205add8e8bb3a1635cbbac59d6def2e0891b145aa553a0e40dd2d0/keyring-23.13.1.tar.gz"
+                "https://files.pythonhosted.org/packages/a5/1c/2bdbcfd5d59dc6274ffb175bc29aa07ecbfab196830e0cfbde7bd861a2ea/keyring-25.4.1.tar.gz"
               ]
             }
           },
-          "rules_python_publish_deps_311_pkginfo_py3_none_any_4b7a555a": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_markdown_it_py_py3_none_any_35521684": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "pkginfo-1.9.6-py3-none-any.whl",
-              "isolated": true,
+              "filename": "markdown_it_py-3.0.0-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "pkginfo==1.9.6",
-              "sha256": "4b7a555a6d5a22169fcc9cf7bfd78d296b0361adad412a346c1226849af5e546",
-              "timeout": 600,
+              "requirement": "markdown-it-py==3.0.0",
+              "sha256": "355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
               "urls": [
-                "https://files.pythonhosted.org/packages/b3/f2/6e95c86a23a30fa205ea6303a524b20cbae27fbee69216377e3d95266406/pkginfo-1.9.6-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_pkginfo_sdist_8fd5896e": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_markdown_it_py_sdist_e3f60a94": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "pkginfo-1.9.6.tar.gz",
-              "isolated": true,
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "markdown-it-py-3.0.0.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "pkginfo==1.9.6",
-              "sha256": "8fd5896e8718a4372f0ea9cc9d96f6417c9b986e23a4d116dda26b62cc29d046",
-              "timeout": 600,
+              "requirement": "markdown-it-py==3.0.0",
+              "sha256": "e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb",
               "urls": [
-                "https://files.pythonhosted.org/packages/b4/1c/89b38e431c20d6b2389ed8b3926c2ab72f58944733ba029354c6d9f69129/pkginfo-1.9.6.tar.gz"
+                "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_mdurl_py3_none_any_84008a41": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "mdurl-0.1.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "mdurl==0.1.2",
+              "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_mdurl_sdist_bb413d29": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "mdurl-0.1.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "mdurl==0.1.2",
+              "sha256": "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_more_itertools_py3_none_any_037b0d32": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "more_itertools-10.5.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "more-itertools==10.5.0",
+              "sha256": "037b0d3203ce90cca8ab1defbbdac29d5f993fc20131f3664dc8d6acfa872aef",
+              "urls": [
+                "https://files.pythonhosted.org/packages/48/7e/3a64597054a70f7c86eb0a7d4fc315b8c1ab932f64883a297bdffeb5f967/more_itertools-10.5.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_more_itertools_sdist_5482bfef": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "more-itertools-10.5.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "more-itertools==10.5.0",
+              "sha256": "5482bfef7849c25dc3c6dd53a6173ae4795da2a41a80faea6700d9f5846c5da6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/51/78/65922308c4248e0eb08ebcbe67c95d48615cc6f27854b6f2e57143e9178f/more-itertools-10.5.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_14c5a72e": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "14c5a72e9fe82aea5fe3072116ad4661af5cf8e8ff8fc5ad3450f123e4925e86",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b3/89/1daff5d9ba5a95a157c092c7c5f39b8dd2b1ddb4559966f808d31cfb67e0/nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_7b7c2a3c": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "7b7c2a3c9eb1a827d42539aa64091640bd275b81e097cd1d8d82ef91ffa2e811",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2c/b6/42fc3c69cabf86b6b81e4c051a9b6e249c5ba9f8155590222c2622961f58/nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_aarch64_42c64511": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "42c64511469005058cd17cc1537578eac40ae9f7200bedcfd1fc1a05f4f8c200",
+              "urls": [
+                "https://files.pythonhosted.org/packages/45/b9/833f385403abaf0023c6547389ec7a7acf141ddd9d1f21573723a6eab39a/nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_armv7l_0411beb0": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "0411beb0589eacb6734f28d5497ca2ed379eafab8ad8c84b31bb5c34072b7164",
+              "urls": [
+                "https://files.pythonhosted.org/packages/05/2b/85977d9e11713b5747595ee61f381bc820749daf83f07b90b6c9964cf932/nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64_5f36b271": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "5f36b271dae35c465ef5e9090e1fdaba4a60a56f0bb0ba03e0932a66f28b9189",
+              "urls": [
+                "https://files.pythonhosted.org/packages/72/f2/5c894d5265ab80a97c68ca36f25c8f6f0308abac649aaf152b74e7e854a8/nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64le_34c03fa7": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "34c03fa78e328c691f982b7c03d4423bdfd7da69cd707fe572f544cf74ac23ad",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ab/a7/375afcc710dbe2d64cfbd69e31f82f3e423d43737258af01f6a56d844085/nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_s390x_19aaba96": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "19aaba96e0f795bd0a6c56291495ff59364f4300d4a39b29a0abc9cb3774a84b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c2/a8/3bb02d0c60a03ad3a112b76c46971e9480efa98a8946677b5a59f60130ca/nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_x86_64_de3ceed6": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "de3ceed6e661954871d6cd78b410213bdcb136f79aafe22aa7182e028b8c7307",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1b/63/6ab90d0e5225ab9780f6c9fb52254fa36b52bb7c188df9201d05b647e5e1/nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_aarch64_f0eca9ca": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "f0eca9ca8628dbb4e916ae2491d72957fdd35f7a5d326b7032a345f111ac07fe",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a3/da/0c4e282bc3cff4a0adf37005fa1fb42257673fbc1bbf7d1ff639ec3d255a/nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_armv7l_3a157ab1": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "3a157ab149e591bb638a55c8c6bcb8cdb559c8b12c13a8affaba6cedfe51713a",
+              "urls": [
+                "https://files.pythonhosted.org/packages/de/81/c291231463d21da5f8bba82c8167a6d6893cc5419b0639801ee5d3aeb8a9/nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_x86_64_36c95d4b": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "36c95d4b70530b320b365659bb5034341316e6a9b30f0b25fa9c9eff4c27a204",
+              "urls": [
+                "https://files.pythonhosted.org/packages/eb/61/73a007c74c37895fdf66e0edcd881f5eaa17a348ff02f4bb4bc906d61085/nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_win_amd64_8ce0f819": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "8ce0f819d2f1933953fca255db2471ad58184a60508f03e6285e5114b6254844",
+              "urls": [
+                "https://files.pythonhosted.org/packages/26/8d/53c5b19c4999bdc6ba95f246f4ef35ca83d7d7423e5e38be43ad66544e5d/nh3-0.2.18-cp37-abi3-win_amd64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_sdist_94a16692": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "nh3-0.2.18.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "94a166927e53972a9698af9542ace4e38b9de50c34352b962f4d9a7d4c927af4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/62/73/10df50b42ddb547a907deeb2f3c9823022580a7a47281e8eae8e003a9639/nh3-0.2.18.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pkginfo_py3_none_any_889a6da2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pkginfo-1.10.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pkginfo==1.10.0",
+              "sha256": "889a6da2ed7ffc58ab5b900d888ddce90bce912f2d2de1dc1c26f4cb9fe65097",
+              "urls": [
+                "https://files.pythonhosted.org/packages/56/09/054aea9b7534a15ad38a363a2bd974c20646ab1582a387a95b8df1bfea1c/pkginfo-1.10.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pkginfo_sdist_5df73835": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "pkginfo-1.10.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pkginfo==1.10.0",
+              "sha256": "5df73835398d10db79f8eecd5cd86b1f6d29317589ea70796994d49399af6297",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2f/72/347ec5be4adc85c182ed2823d8d1c7b51e13b9a6b0c1aae59582eca652df/pkginfo-1.10.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pycparser_py3_none_any_c3702b6d": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "pycparser-2.22-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pycparser==2.22",
+              "sha256": "c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc",
+              "urls": [
+                "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pycparser_sdist_491c8be9": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "pycparser-2.22.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pycparser==2.22",
+              "sha256": "491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pygments_py3_none_any_b8e6aca0": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pygments-2.18.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pygments==2.18.0",
+              "sha256": "b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pygments_sdist_786ff802": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "pygments-2.18.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pygments==2.18.0",
+              "sha256": "786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pywin32_ctypes_py3_none_any_8a151337": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pywin32_ctypes-0.2.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pywin32-ctypes==0.2.3",
+              "sha256": "8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pywin32_ctypes_sdist_d162dc04": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "pywin32-ctypes-0.2.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pywin32-ctypes==0.2.3",
+              "sha256": "d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755",
+              "urls": [
+                "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_readme_renderer_py3_none_any_2fbca89b": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "readme_renderer-44.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "readme-renderer==44.0",
+              "sha256": "2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151",
+              "urls": [
+                "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_readme_renderer_sdist_8712034e": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "readme_renderer-44.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "readme-renderer==44.0",
+              "sha256": "8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_py3_none_any_70761cfe": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "requests-2.32.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests==2.32.3",
+              "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_sdist_55365417": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "requests-2.32.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests==2.32.3",
+              "sha256": "55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+              "urls": [
+                "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_toolbelt_py2_none_any_cccfdd66": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "requests_toolbelt-1.0.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests-toolbelt==1.0.0",
+              "sha256": "cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06",
+              "urls": [
+                "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_toolbelt_sdist_7681a0a3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "requests-toolbelt-1.0.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests-toolbelt==1.0.0",
+              "sha256": "7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz"
               ]
             }
           },
           "rules_python_publish_deps_311_rfc3986_py2_none_any_50b1502b": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
               "filename": "rfc3986-2.0.0-py2.py3-none-any.whl",
-              "isolated": true,
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
               "requirement": "rfc3986==2.0.0",
               "sha256": "50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd",
-              "timeout": 600,
               "urls": [
                 "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl"
               ]
             }
           },
           "rules_python_publish_deps_311_rfc3986_sdist_97aacf9d": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
               ],
               "filename": "rfc3986-2.0.0.tar.gz",
-              "isolated": true,
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
               "requirement": "rfc3986==2.0.0",
               "sha256": "97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c",
-              "timeout": 600,
               "urls": [
                 "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz"
               ]
             }
           },
-          "rules_python_publish_deps_311_urllib3_py2_none_any_75edcdc2": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_rich_py3_none_any_9836f509": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "urllib3-1.26.14-py2.py3-none-any.whl",
-              "isolated": true,
+              "filename": "rich-13.9.3-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "urllib3==1.26.14",
-              "sha256": "75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1",
-              "timeout": 600,
+              "requirement": "rich==13.9.3",
+              "sha256": "9836f5096eb2172c9e77df411c1b009bace4193d6a481d534fea75ebba758283",
               "urls": [
-                "https://files.pythonhosted.org/packages/fe/ca/466766e20b767ddb9b951202542310cba37ea5f2d792dae7589f1741af58/urllib3-1.26.14-py2.py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/9a/e2/10e9819cf4a20bd8ea2f5dabafc2e6bf4a78d6a0965daeb60a4b34d1c11f/rich-13.9.3-py3-none-any.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_urllib3_sdist_076907bf": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_rich_sdist_bc1e01b8": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "urllib3-1.26.14.tar.gz",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "urllib3==1.26.14",
-              "sha256": "076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/c5/52/fe421fb7364aa738b3506a2d99e4f3a56e079c0a798e9f4fa5e14c60922f/urllib3-1.26.14.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_urllib3_py2_none_any_34b97092": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
               ],
-              "filename": "urllib3-1.26.18-py2.py3-none-any.whl",
-              "isolated": true,
+              "filename": "rich-13.9.3.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "urllib3==1.26.18",
-              "sha256": "34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07",
-              "timeout": 600,
+              "requirement": "rich==13.9.3",
+              "sha256": "bc1e01b899537598cf02579d2b9f4a415104d3fc439313a7a2c165d76557a08e",
               "urls": [
-                "https://files.pythonhosted.org/packages/b0/53/aa91e163dcfd1e5b82d8a890ecf13314e3e149c05270cc644581f77f17fd/urllib3-1.26.18-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_urllib3_sdist_f8ecc1bb": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "urllib3-1.26.18.tar.gz",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "urllib3==1.26.18",
-              "sha256": "f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/0c/39/64487bf07df2ed854cc06078c27c0d0abc59bd27b32232876e403c333a08/urllib3-1.26.18.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_docutils_py3_none_any_5e1de4d8": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "docutils-0.19-py3-none-any.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "docutils==0.19",
-              "sha256": "5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_docutils_sdist_33995a67": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "docutils-0.19.tar.gz",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "docutils==0.19",
-              "sha256": "33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/6b/5c/330ea8d383eb2ce973df34d1239b3b21e91cd8c865d21ff82902d952f91f/docutils-0.19.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pygments_py3_none_any_fa7bd7bd": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "Pygments-2.14.0-py3-none-any.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pygments==2.14.0",
-              "sha256": "fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/0b/42/d9d95cc461f098f204cd20c85642ae40fbff81f74c300341b8d0e0df14e0/Pygments-2.14.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pygments_sdist_b3ed06a9": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "Pygments-2.14.0.tar.gz",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pygments==2.14.0",
-              "sha256": "b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/da/6a/c427c06913204e24de28de5300d3f0e809933f376e0b7df95194b2bb3f71/Pygments-2.14.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_requests_py3_none_any_64299f49": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "requests-2.28.2-py3-none-any.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "requests==2.28.2",
-              "sha256": "64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_requests_sdist_98b1b278": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "requests-2.28.2.tar.gz",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "requests==2.28.2",
-              "sha256": "98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/9d/ee/391076f5937f0a8cdf5e53b701ffc91753e87b07d66bae4a09aa671897bf/requests-2.28.2.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pycparser_py2_none_any_8ee45429": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
-              ],
-              "filename": "pycparser-2.21-py2.py3-none-any.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pycparser==2.21",
-              "sha256": "8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pycparser_sdist_e644fdec": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
-              ],
-              "filename": "pycparser-2.21.tar.gz",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pycparser==2.21",
-              "sha256": "e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/5e/0b/95d387f5f4433cb0f53ff7ad859bd2c6051051cebbb564f139a999ab46de/pycparser-2.21.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_cp37_abi3_musllinux_1_1_x86_64_068bc551": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
-              ],
-              "filename": "cryptography-41.0.6-cp37-abi3-musllinux_1_1_x86_64.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==41.0.6",
-              "sha256": "068bc551698c234742c40049e46840843f3d98ad7ce265fd2bd4ec0d11306596",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/a4/37/38d1340a8eb720dac78fde5d14742c6bb22a4b5f750ac869ef4eaaa795e0/cryptography-41.0.6-cp37-abi3-musllinux_1_1_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_cp37_abi3_musllinux_1_1_aarch64_5daeb18e": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
-              ],
-              "filename": "cryptography-41.0.6-cp37-abi3-musllinux_1_1_aarch64.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==41.0.6",
-              "sha256": "5daeb18e7886a358064a68dbcaf441c036cbdb7da52ae744e7b9207b04d3908c",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/07/68/d41ba60a16ff4e64965a857fcf2041f893362ae62c5b88d8b958196e2bed/cryptography-41.0.6-cp37-abi3-musllinux_1_1_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_cp37_abi3_manylinux_2_17_aarch64_afda76d8": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
-              ],
-              "filename": "cryptography-41.0.6-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==41.0.6",
-              "sha256": "afda76d84b053923c27ede5edc1ed7d53e3c9f475ebaf63c68e69f1403c405a8",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/88/bd/0c1dc2d29a6eed5ac0491d9b0ba3e118ac8d36b532bb812b3047e3b87a1e/cryptography-41.0.6-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_cp37_abi3_manylinux_2_28_x86_64_b648fe2a": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
-              ],
-              "filename": "cryptography-41.0.6-cp37-abi3-manylinux_2_28_x86_64.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==41.0.6",
-              "sha256": "b648fe2a45e426aaee684ddca2632f62ec4613ef362f4d681a9a6283d10e079d",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/1e/7a/22192740f36448bb763846da291c13fa66dae92917b5a1cd032ea5dfe2d1/cryptography-41.0.6-cp37-abi3-manylinux_2_28_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_cp37_abi3_manylinux_2_17_x86_64_da46e2b5": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
-              ],
-              "filename": "cryptography-41.0.6-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==41.0.6",
-              "sha256": "da46e2b5df770070412c46f87bac0849b8d685c5f2679771de277a422c7d0b86",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/ce/4e/54960380dda23ceb2027500e568aeafd6f06ce031847d7f2d3157f2bd12b/cryptography-41.0.6-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_cp37_abi3_manylinux_2_28_aarch64_ff369dd1": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
-              ],
-              "filename": "cryptography-41.0.6-cp37-abi3-manylinux_2_28_aarch64.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==41.0.6",
-              "sha256": "ff369dd19e8fe0528b02e8df9f2aeb2479f89b1270d90f96a63500afe9af5cae",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/0e/dd/6043bf697d30dc4277cc1608af1145d6076fdd0f00283626bf916d7cde8f/cryptography-41.0.6-cp37-abi3-manylinux_2_28_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_cryptography_sdist_422e3e31": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
-              ],
-              "filename": "cryptography-41.0.6.tar.gz",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "cryptography==41.0.6",
-              "sha256": "422e3e31d63743855e43e5a6fcc8b4acab860f560f9321b0ee6269cc7ed70cc3",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/4d/b4/828991d82d3f1b6f21a0f8cfa54337ed33fdb52135f694130060839cfc33/cryptography-41.0.6.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_webencodings_py2_none_any_a0af1213": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "webencodings-0.5.1-py2.py3-none-any.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "webencodings==0.5.1",
-              "sha256": "a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_webencodings_sdist_b36a1c24": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "webencodings-0.5.1.tar.gz",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "webencodings==0.5.1",
-              "sha256": "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz"
+                "https://files.pythonhosted.org/packages/d9/e9/cf9ef5245d835065e6673781dbd4b8911d352fb770d56cf0879cf11b7ee1/rich-13.9.3.tar.gz"
               ]
             }
           },
           "rules_python_publish_deps_311_secretstorage_py3_none_any_f356e662": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
               ],
               "filename": "SecretStorage-3.3.3-py3-none-any.whl",
-              "isolated": true,
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
               "requirement": "secretstorage==3.3.3",
               "sha256": "f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99",
-              "timeout": 600,
               "urls": [
                 "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl"
               ]
             }
           },
           "rules_python_publish_deps_311_secretstorage_sdist_2403533e": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
               ],
               "filename": "SecretStorage-3.3.3.tar.gz",
-              "isolated": true,
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
               "requirement": "secretstorage==3.3.3",
               "sha256": "2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77",
-              "timeout": 600,
               "urls": [
                 "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz"
               ]
             }
           },
-          "rules_python_publish_deps_311_jaraco_classes_py3_none_any_2353de32": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_twine_py3_none_any_215dbe7b": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "jaraco.classes-3.2.3-py3-none-any.whl",
-              "isolated": true,
+              "filename": "twine-5.1.1-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "jaraco-classes==3.2.3",
-              "sha256": "2353de3288bc6b82120752201c6b1c1a14b058267fa424ed5ce5984e3b922158",
-              "timeout": 600,
+              "requirement": "twine==5.1.1",
+              "sha256": "215dbe7b4b94c2c50a7315c0275d2258399280fbb7d04182c7e55e24b5f93997",
               "urls": [
-                "https://files.pythonhosted.org/packages/60/28/220d3ae0829171c11e50dded4355d17824d60895285631d7eb9dee0ab5e5/jaraco.classes-3.2.3-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/5d/ec/00f9d5fd040ae29867355e559a94e9a8429225a0284a3f5f091a3878bfc0/twine-5.1.1-py3-none-any.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_jaraco_classes_sdist_89559fa5": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_twine_sdist_9aa08251": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "jaraco.classes-3.2.3.tar.gz",
-              "isolated": true,
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "twine-5.1.1.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "jaraco-classes==3.2.3",
-              "sha256": "89559fa5c1d3c34eff6f631ad80bb21f378dbcbb35dd161fd2c6b93f5be2f98a",
-              "timeout": 600,
+              "requirement": "twine==5.1.1",
+              "sha256": "9aa0825139c02b3434d913545c7b847a21c835e11597f5255842d457da2322db",
               "urls": [
-                "https://files.pythonhosted.org/packages/bf/02/a956c9bfd2dfe60b30c065ed8e28df7fcf72b292b861dca97e951c145ef6/jaraco.classes-3.2.3.tar.gz"
+                "https://files.pythonhosted.org/packages/77/68/bd982e5e949ef8334e6f7dcf76ae40922a8750aa2e347291ae1477a4782b/twine-5.1.1.tar.gz"
               ]
             }
           },
-          "rules_python_publish_deps_311_markdown_it_py_py3_none_any_93de681e": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_urllib3_py3_none_any_ca899ca0": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "markdown_it_py-2.1.0-py3-none-any.whl",
-              "isolated": true,
+              "filename": "urllib3-2.2.3-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "markdown-it-py==2.1.0",
-              "sha256": "93de681e5c021a432c63147656fe21790bc01231e0cd2da73626f1aa3ac0fe27",
-              "timeout": 600,
+              "requirement": "urllib3==2.2.3",
+              "sha256": "ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
               "urls": [
-                "https://files.pythonhosted.org/packages/f9/3f/ecd1b708973b9a3e4574b43cffc1ce8eb98696da34f1a1c44a68c3c0d737/markdown_it_py-2.1.0-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_markdown_it_py_sdist_cf7e59fe": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_urllib3_sdist_e7d814a8": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "markdown-it-py-2.1.0.tar.gz",
-              "isolated": true,
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "urllib3-2.2.3.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "markdown-it-py==2.1.0",
-              "sha256": "cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da",
-              "timeout": 600,
+              "requirement": "urllib3==2.2.3",
+              "sha256": "e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9",
               "urls": [
-                "https://files.pythonhosted.org/packages/33/e9/ac8a93e9eda3891ecdfecf5e01c060bbd2c44d4e3e77efc83b9c7ce9db32/markdown-it-py-2.1.0.tar.gz"
+                "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz"
               ]
             }
           },
-          "rules_python_publish_deps_311_more_itertools_py3_none_any_250e83d7": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_zipp_py3_none_any_a817ac80": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "more_itertools-9.0.0-py3-none-any.whl",
-              "isolated": true,
+              "filename": "zipp-3.20.2-py3-none-any.whl",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "more-itertools==9.0.0",
-              "sha256": "250e83d7e81d0c87ca6bd942e6aeab8cc9daa6096d12c5308f3f92fa5e5c1f41",
-              "timeout": 600,
+              "requirement": "zipp==3.20.2",
+              "sha256": "a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350",
               "urls": [
-                "https://files.pythonhosted.org/packages/5d/87/1ec3fcc09d2c04b977eabf8a1083222f82eaa2f46d5a4f85f403bf8e7b30/more_itertools-9.0.0-py3-none-any.whl"
+                "https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl"
               ]
             }
           },
-          "rules_python_publish_deps_311_more_itertools_sdist_5a6257e4": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+          "rules_python_publish_deps_311_zipp_sdist_bc9eb26f": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
             "attributes": {
               "dep_template": "@rules_python_publish_deps//{name}:{target}",
               "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
               ],
-              "filename": "more-itertools-9.0.0.tar.gz",
-              "isolated": true,
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "zipp-3.20.2.tar.gz",
               "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
               "repo": "rules_python_publish_deps_311",
-              "requirement": "more-itertools==9.0.0",
-              "sha256": "5a6257e40878ef0520b1803990e3e22303a41b5714006c32a3fd8304b26ea1ab",
-              "timeout": 600,
+              "requirement": "zipp==3.20.2",
+              "sha256": "bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29",
               "urls": [
-                "https://files.pythonhosted.org/packages/13/b3/397aa9668da8b1f0c307bc474608653d46122ae0563d1d32f60e24fa0cbd/more-itertools-9.0.0.tar.gz"
+                "https://files.pythonhosted.org/packages/54/bf/5c0000c44ebc80123ecbdddba1f5dcd94a5ada602a9c225d84b5aaa55e86/zipp-3.20.2.tar.gz"
               ]
             }
           },
-          "rules_python_publish_deps_311_readme_renderer_py3_none_any_f67a16ca": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
+          "rules_fuzzing_py_deps": {
+            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
             "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
+              "repo_name": "rules_fuzzing_py_deps",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "absl_py": "{\"rules_fuzzing_py_deps_310_absl_py\":[{\"version\":\"3.10\"}],\"rules_fuzzing_py_deps_311_absl_py\":[{\"version\":\"3.11\"}],\"rules_fuzzing_py_deps_312_absl_py\":[{\"version\":\"3.12\"}],\"rules_fuzzing_py_deps_38_absl_py\":[{\"version\":\"3.8\"}],\"rules_fuzzing_py_deps_39_absl_py\":[{\"version\":\"3.9\"}]}",
+                "six": "{\"rules_fuzzing_py_deps_310_six\":[{\"version\":\"3.10\"}],\"rules_fuzzing_py_deps_311_six\":[{\"version\":\"3.11\"}],\"rules_fuzzing_py_deps_312_six\":[{\"version\":\"3.12\"}],\"rules_fuzzing_py_deps_38_six\":[{\"version\":\"3.8\"}],\"rules_fuzzing_py_deps_39_six\":[{\"version\":\"3.9\"}]}"
+              },
+              "packages": [
+                "absl_py",
+                "six"
               ],
-              "filename": "readme_renderer-37.3-py3-none-any.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "readme-renderer==37.3",
-              "sha256": "f67a16caedfa71eef48a31b39708637a6f4664c4394801a7b0d6432d13907343",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/97/52/fd8a77d6f0a9ddeb26ed8fb334e01ac546106bf0c5b8e40dc826c5bd160f/readme_renderer-37.3-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_readme_renderer_sdist_cd653186": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "readme_renderer-37.3.tar.gz",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "readme-renderer==37.3",
-              "sha256": "cd653186dfc73055656f090f227f5cb22a046d7f71a841dfa305f55c9a513273",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/81/c3/d20152fcd1986117b898f66928938f329d0c91ddc47f081c58e64e0f51dc/readme_renderer-37.3.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_requests_toolbelt_py2_none_any_18565aa5": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "requests_toolbelt-0.10.1-py2.py3-none-any.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "requests-toolbelt==0.10.1",
-              "sha256": "18565aa58116d9951ac39baa288d3adb5b3ff975c4f25eee78555d89e8f247f7",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/05/d3/bf87a36bff1cb88fd30a509fd366c70ec30676517ee791b2f77e0e29817a/requests_toolbelt-0.10.1-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_requests_toolbelt_sdist_62e09f7f": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "requests-toolbelt-0.10.1.tar.gz",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "requests-toolbelt==0.10.1",
-              "sha256": "62e09f7ff5ccbda92772a29f394a49c3ad6cb181d568b1337626b2abb628a63d",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/0c/4c/07f01c6ac44f7784fa399137fbc8d0cdc1b5d35304e8c0f278ad82105b58/requests-toolbelt-0.10.1.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_universal2_0298eaff": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.0.1-cp311-cp311-macosx_10_9_universal2.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "0298eafff88c99982a4cf66ba2efa1128e4ddaca0b05eec4c456bbc7db691d8d",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/37/00/ca188e0a2b3cd3184cdd2521b8765cf579327d128caa8aedc3dc7614020a/charset_normalizer-3.0.1-cp311-cp311-macosx_10_9_universal2.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_ppc64le_0c0a5902": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "0c0a590235ccd933d9892c627dec5bc7511ce6ad6c1011fdf5b11363022746c1",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/12/e5/aa09a1c39c3e444dd223d63e2c816c18ed78d035cff954143b2a539bdc9e/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_aarch64_14e76c0f": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "14e76c0f23218b8f46c4d87018ca2e441535aed3632ca134b10239dfb6dadd6b",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/c0/4d/6b82099e3f25a9ed87431e2f51156c14f3a9ce8fad73880a3856cd95f1d5/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_1_s390x_4a8fcf28": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_s390x.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "4a8fcf28c05c1f6d7e177a9a46a1c52798bfe2ad80681d275b10dcf317deaf0b",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/80/54/183163f9910936e57a60ee618f4f5cc91c2f8333ee2d4ebc6c50f6c8684d/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_s390x.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_1_ppc64le_5995f016": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_ppc64le.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "5995f0164fa7df59db4746112fec3f49c461dd6b31b841873443bdb077c13cfc",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/86/eb/31c9025b4ed7eddd930c5f2ac269efb953de33140608c7539675d74a2081/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_ppc64le.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_1_aarch64_72966d1b": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_aarch64.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "72966d1b297c741541ca8cf1223ff262a6febe52481af742036a0b296e35fa5a",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/01/ff/9ee4a44e8c32fe96dfc12daa42f29294608a55eadc88f327939327fb20fb/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_aarch64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_1_x86_64_761e8904": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_x86_64.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "761e8904c07ad053d285670f36dd94e1b6ab7f16ce62b9805c475b7aa1cffde6",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/82/49/ab81421d5aa25bc8535896a017c93204cb4051f2a4e72b1ad8f3b594e072/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_x86_64_79909e27": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "79909e27e8e4fcc9db4addea88aa63f6423ebb171db091fb4373e3312cb6d603",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/d9/7a/60d45c9453212b30eebbf8b5cddbdef330eebddfcf335bce7920c43fb72e/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_py3_none_any_7e189e2e": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.0.1-py3-none-any.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "7e189e2e1d3ed2f4aebabd2d5b0f931e883676e51c7624826e0a4e5fe8a0bf24",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/68/2b/02e9d6a98ddb73fa238d559a9edcc30b247b8dc4ee848b6184c936e99dc0/charset_normalizer-3.0.1-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_11_0_arm64_87701167": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.0.1-cp311-cp311-macosx_11_0_arm64.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "87701167f2a5c930b403e9756fab1d31d4d4da52856143b609e30a1ce7160f3c",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/02/49/78b4c1bc8b1b0e0fc66fb31ce30d8302f10a1412ba75de72c57532f0beb0/charset_normalizer-3.0.1-cp311-cp311-macosx_11_0_arm64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_s390x_8c7fe7af": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "8c7fe7afa480e3e82eed58e0ca89f751cd14d767638e2550c77a92a9e749c317",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/df/c5/dd3a17a615775d0ffc3e12b0e47833d8b7e0a4871431dad87a3f92382a19/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_win_amd64_9ab77acb": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.0.1-cp311-cp311-win_amd64.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "9ab77acb98eba3fd2a85cd160851816bfce6871d944d885febf012713f06659c",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/2e/7b/5053a4a46fac017fd2aea3dc9abdd9983fd4cef153b6eb6aedcb0d7cb6e3/charset_normalizer-3.0.1-cp311-cp311-win_amd64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_x86_64_a8d0fc94": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "charset_normalizer-3.0.1-cp311-cp311-macosx_10_9_x86_64.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "a8d0fc946c784ff7f7c3742310cc8a57c5c6dc31631269876a88b809dbeff3d3",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/90/59/941e2e5ae6828a688c6437ad16e026eb3606d0cfdd13ea5c9090980f3ffd/charset_normalizer-3.0.1-cp311-cp311-macosx_10_9_x86_64.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_charset_normalizer_sdist_ebea339a": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "charset-normalizer-3.0.1.tar.gz",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "charset-normalizer==3.0.1",
-              "sha256": "ebea339af930f8ca5d7a699b921106c6e29c617fe9606fa7baa043c1cdae326f",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/96/d7/1675d9089a1f4677df5eb29c3f8b064aa1e70c1251a0a8a127803158942d/charset-normalizer-3.0.1.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_importlib_metadata_py3_none_any_7efb448e": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "importlib_metadata-6.0.0-py3-none-any.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "importlib-metadata==6.0.0",
-              "sha256": "7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_importlib_metadata_sdist_e354bede": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "linux_aarch64",
-                "linux_arm",
-                "linux_ppc",
-                "linux_s390x",
-                "linux_x86_64",
-                "osx_aarch64",
-                "osx_x86_64",
-                "windows_x86_64"
-              ],
-              "filename": "importlib_metadata-6.0.0.tar.gz",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "importlib-metadata==6.0.0",
-              "sha256": "e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pywin32_ctypes_py2_none_any_9dc2d991": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "windows_x86_64"
-              ],
-              "filename": "pywin32_ctypes-0.2.0-py2.py3-none-any.whl",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pywin32-ctypes==0.2.0",
-              "sha256": "9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/9e/4b/3ab2720f1fa4b4bc924ef1932b842edf10007e4547ea8157b0b9fc78599a/pywin32_ctypes-0.2.0-py2.py3-none-any.whl"
-              ]
-            }
-          },
-          "rules_python_publish_deps_311_pywin32_ctypes_sdist_24ffc3b3": {
-            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
-            "ruleClassName": "whl_library",
-            "attributes": {
-              "dep_template": "@rules_python_publish_deps//{name}:{target}",
-              "experimental_target_platforms": [
-                "windows_x86_64"
-              ],
-              "filename": "pywin32-ctypes-0.2.0.tar.gz",
-              "isolated": true,
-              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
-              "quiet": true,
-              "repo": "rules_python_publish_deps_311",
-              "requirement": "pywin32-ctypes==0.2.0",
-              "sha256": "24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942",
-              "timeout": 600,
-              "urls": [
-                "https://files.pythonhosted.org/packages/7a/7d/0dbc4c99379452a819b0fb075a0ffbb98611df6b6d59f54db67367af5bc0/pywin32-ctypes-0.2.0.tar.gz"
-              ]
+              "groups": {}
             }
           },
           "rules_python_publish_deps": {
-            "bzlFile": "@@rules_python~//python/private/bzlmod:pip_repository.bzl",
-            "ruleClassName": "pip_repository",
+            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
             "attributes": {
               "repo_name": "rules_python_publish_deps",
+              "extra_hub_aliases": {},
               "whl_map": {
-                "six": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"six-1.16.0-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_six_py2_none_any_8abb2f1d\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"six-1.16.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_six_sdist_1e61c374\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "cffi": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_aarch64_3548db28\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_ppc64le_91fc98ad\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_x86_64_94411f22\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_x86_64_cc4d65ae\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cffi-1.15.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_cffi_sdist_d400bfb9\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "idna": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"idna-3.4-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_idna_py3_none_any_90b77e79\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"idna-3.4.tar.gz\",\"repo\":\"rules_python_publish_deps_311_idna_sdist_814f528e\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "rich": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rich-13.2.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_rich_py3_none_any_7c963f0d\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rich-13.2.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_rich_sdist_f1a00cdd\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "zipp": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"zipp-3.11.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_zipp_py3_none_any_83a28fcb\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"zipp-3.11.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_zipp_sdist_a7a22e05\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "mdurl": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"mdurl-0.1.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_mdurl_py3_none_any_84008a41\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"mdurl-0.1.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_mdurl_sdist_bb413d29\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "twine": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"twine-4.0.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_twine_py3_none_any_929bc3c2\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"twine-4.0.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_twine_sdist_9e102ef5\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "bleach": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"bleach-6.0.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_bleach_py3_none_any_33c16e33\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"bleach-6.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_bleach_sdist_1a1a85c1\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "certifi": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"certifi-2022.12.7-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_certifi_py3_none_any_4ad3232f\",\"target_platforms\":[\"linux_aarch64\",\"linux_arm\",\"linux_ppc\",\"linux_s390x\",\"linux_x86_64\"],\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"certifi-2022.12.7.tar.gz\",\"repo\":\"rules_python_publish_deps_311_certifi_sdist_35824b4c\",\"target_platforms\":[\"linux_aarch64\",\"linux_arm\",\"linux_ppc\",\"linux_s390x\",\"linux_x86_64\"],\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"certifi-2023.7.22-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_certifi_py3_none_any_92d60375\",\"target_platforms\":[\"osx_aarch64\",\"osx_x86_64\",\"windows_x86_64\"],\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"certifi-2023.7.22.tar.gz\",\"repo\":\"rules_python_publish_deps_311_certifi_sdist_539cc1d1\",\"target_platforms\":[\"osx_aarch64\",\"osx_x86_64\",\"windows_x86_64\"],\"version\":\"3.11\"}]",
-                "jeepney": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jeepney-0.8.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jeepney_py3_none_any_c0a454ad\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jeepney-0.8.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jeepney_sdist_5efe48d2\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "keyring": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"keyring-23.13.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_keyring_py3_none_any_771ed2a9\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"keyring-23.13.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_keyring_sdist_ba2e15a9\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "pkginfo": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pkginfo-1.9.6-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pkginfo_py3_none_any_4b7a555a\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pkginfo-1.9.6.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pkginfo_sdist_8fd5896e\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "rfc3986": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rfc3986-2.0.0-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_rfc3986_py2_none_any_50b1502b\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"rfc3986-2.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_rfc3986_sdist_97aacf9d\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "urllib3": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"urllib3-1.26.14-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_urllib3_py2_none_any_75edcdc2\",\"target_platforms\":[\"linux_aarch64\",\"linux_arm\",\"linux_ppc\",\"linux_s390x\",\"linux_x86_64\"],\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"urllib3-1.26.14.tar.gz\",\"repo\":\"rules_python_publish_deps_311_urllib3_sdist_076907bf\",\"target_platforms\":[\"linux_aarch64\",\"linux_arm\",\"linux_ppc\",\"linux_s390x\",\"linux_x86_64\"],\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"urllib3-1.26.18-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_urllib3_py2_none_any_34b97092\",\"target_platforms\":[\"osx_aarch64\",\"osx_x86_64\",\"windows_x86_64\"],\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"urllib3-1.26.18.tar.gz\",\"repo\":\"rules_python_publish_deps_311_urllib3_sdist_f8ecc1bb\",\"target_platforms\":[\"osx_aarch64\",\"osx_x86_64\",\"windows_x86_64\"],\"version\":\"3.11\"}]",
-                "docutils": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"docutils-0.19-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_docutils_py3_none_any_5e1de4d8\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"docutils-0.19.tar.gz\",\"repo\":\"rules_python_publish_deps_311_docutils_sdist_33995a67\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "pygments": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"Pygments-2.14.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pygments_py3_none_any_fa7bd7bd\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"Pygments-2.14.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pygments_sdist_b3ed06a9\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "requests": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-2.28.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_requests_py3_none_any_64299f49\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-2.28.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_requests_sdist_98b1b278\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "pycparser": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pycparser-2.21-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pycparser_py2_none_any_8ee45429\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pycparser-2.21.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pycparser_sdist_e644fdec\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "cryptography": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-41.0.6-cp37-abi3-musllinux_1_1_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp37_abi3_musllinux_1_1_x86_64_068bc551\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-41.0.6-cp37-abi3-musllinux_1_1_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp37_abi3_musllinux_1_1_aarch64_5daeb18e\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-41.0.6-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp37_abi3_manylinux_2_17_aarch64_afda76d8\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-41.0.6-cp37-abi3-manylinux_2_28_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp37_abi3_manylinux_2_28_x86_64_b648fe2a\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-41.0.6-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp37_abi3_manylinux_2_17_x86_64_da46e2b5\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-41.0.6-cp37-abi3-manylinux_2_28_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp37_abi3_manylinux_2_28_aarch64_ff369dd1\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"cryptography-41.0.6.tar.gz\",\"repo\":\"rules_python_publish_deps_311_cryptography_sdist_422e3e31\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "webencodings": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"webencodings-0.5.1-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_webencodings_py2_none_any_a0af1213\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"webencodings-0.5.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_webencodings_sdist_b36a1c24\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "secretstorage": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"SecretStorage-3.3.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_secretstorage_py3_none_any_f356e662\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"SecretStorage-3.3.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_secretstorage_sdist_2403533e\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "jaraco_classes": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.classes-3.2.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_classes_py3_none_any_2353de32\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"jaraco.classes-3.2.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_classes_sdist_89559fa5\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "markdown_it_py": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"markdown_it_py-2.1.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_markdown_it_py_py3_none_any_93de681e\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"markdown-it-py-2.1.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_markdown_it_py_sdist_cf7e59fe\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "more_itertools": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"more_itertools-9.0.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_more_itertools_py3_none_any_250e83d7\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"more-itertools-9.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_more_itertools_sdist_5a6257e4\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "readme_renderer": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"readme_renderer-37.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_readme_renderer_py3_none_any_f67a16ca\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"readme_renderer-37.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_readme_renderer_sdist_cd653186\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "requests_toolbelt": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests_toolbelt-0.10.1-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_requests_toolbelt_py2_none_any_18565aa5\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"requests-toolbelt-0.10.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_requests_toolbelt_sdist_62e09f7f\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "charset_normalizer": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.0.1-cp311-cp311-macosx_10_9_universal2.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_universal2_0298eaff\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_ppc64le_0c0a5902\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_aarch64_14e76c0f\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_1_s390x_4a8fcf28\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_1_ppc64le_5995f016\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_1_aarch64_72966d1b\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_1_x86_64_761e8904\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_x86_64_79909e27\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.0.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_py3_none_any_7e189e2e\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.0.1-cp311-cp311-macosx_11_0_arm64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_11_0_arm64_87701167\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_s390x_8c7fe7af\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.0.1-cp311-cp311-win_amd64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_win_amd64_9ab77acb\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset_normalizer-3.0.1-cp311-cp311-macosx_10_9_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_x86_64_a8d0fc94\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"charset-normalizer-3.0.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_sdist_ebea339a\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "importlib_metadata": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"importlib_metadata-6.0.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_importlib_metadata_py3_none_any_7efb448e\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"importlib_metadata-6.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_importlib_metadata_sdist_e354bede\",\"target_platforms\":null,\"version\":\"3.11\"}]",
-                "pywin32_ctypes": "[{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pywin32_ctypes-0.2.0-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pywin32_ctypes_py2_none_any_9dc2d991\",\"target_platforms\":null,\"version\":\"3.11\"},{\"config_setting\":\"//_config:is_python_3.11\",\"filename\":\"pywin32-ctypes-0.2.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pywin32_ctypes_sdist_24ffc3b3\",\"target_platforms\":null,\"version\":\"3.11\"}]"
+                "backports_tarfile": "{\"rules_python_publish_deps_311_backports_tarfile_py3_none_any_77e284d7\":[{\"filename\":\"backports.tarfile-1.2.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_backports_tarfile_sdist_d75e02c2\":[{\"filename\":\"backports_tarfile-1.2.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "certifi": "{\"rules_python_publish_deps_311_certifi_py3_none_any_922820b5\":[{\"filename\":\"certifi-2024.8.30-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_certifi_sdist_bec941d2\":[{\"filename\":\"certifi-2024.8.30.tar.gz\",\"version\":\"3.11\"}]}",
+                "cffi": "{\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_aarch64_a1ed2dd2\":[{\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_ppc64le_46bf4316\":[{\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_s390x_a24ed04c\":[{\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_x86_64_610faea7\":[{\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_aarch64_a9b15d49\":[{\"filename\":\"cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_x86_64_fc48c783\":[{\"filename\":\"cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cffi_sdist_1c39c601\":[{\"filename\":\"cffi-1.17.1.tar.gz\",\"version\":\"3.11\"}]}",
+                "charset_normalizer": "{\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_universal2_0d99dd8f\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_x86_64_c57516e5\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_11_0_arm64_6dba5d19\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_aarch64_bf4475b8\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_ppc64le_ce031db0\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_s390x_8ff4e7cd\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_x86_64_3710a975\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_aarch64_47334db7\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_ppc64le_f1a2f519\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_s390x_63bc5c4a\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_x86_64_bcb4f8ea\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_win_amd64_cee4373f\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_py3_none_any_fe9f97fe\":[{\"filename\":\"charset_normalizer-3.4.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_sdist_223217c3\":[{\"filename\":\"charset_normalizer-3.4.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "cryptography": "{\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_aarch64_846da004\":[{\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_x86_64_0f996e72\":[{\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_aarch64_f7b178f1\":[{\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_x86_64_c2e6fc39\":[{\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_aarch64_e1be4655\":[{\"filename\":\"cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_x86_64_df6b6c6d\":[{\"filename\":\"cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cryptography_sdist_315b9001\":[{\"filename\":\"cryptography-43.0.3.tar.gz\",\"version\":\"3.11\"}]}",
+                "docutils": "{\"rules_python_publish_deps_311_docutils_py3_none_any_dafca5b9\":[{\"filename\":\"docutils-0.21.2-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_docutils_sdist_3a6b1873\":[{\"filename\":\"docutils-0.21.2.tar.gz\",\"version\":\"3.11\"}]}",
+                "idna": "{\"rules_python_publish_deps_311_idna_py3_none_any_946d195a\":[{\"filename\":\"idna-3.10-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_idna_sdist_12f65c9b\":[{\"filename\":\"idna-3.10.tar.gz\",\"version\":\"3.11\"}]}",
+                "importlib_metadata": "{\"rules_python_publish_deps_311_importlib_metadata_py3_none_any_45e54197\":[{\"filename\":\"importlib_metadata-8.5.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_importlib_metadata_sdist_71522656\":[{\"filename\":\"importlib_metadata-8.5.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "jaraco_classes": "{\"rules_python_publish_deps_311_jaraco_classes_py3_none_any_f662826b\":[{\"filename\":\"jaraco.classes-3.4.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_jaraco_classes_sdist_47a024b5\":[{\"filename\":\"jaraco.classes-3.4.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "jaraco_context": "{\"rules_python_publish_deps_311_jaraco_context_py3_none_any_f797fc48\":[{\"filename\":\"jaraco.context-6.0.1-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_jaraco_context_sdist_9bae4ea5\":[{\"filename\":\"jaraco_context-6.0.1.tar.gz\",\"version\":\"3.11\"}]}",
+                "jaraco_functools": "{\"rules_python_publish_deps_311_jaraco_functools_py3_none_any_ad159f13\":[{\"filename\":\"jaraco.functools-4.1.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_jaraco_functools_sdist_70f7e0e2\":[{\"filename\":\"jaraco_functools-4.1.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "jeepney": "{\"rules_python_publish_deps_311_jeepney_py3_none_any_c0a454ad\":[{\"filename\":\"jeepney-0.8.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_jeepney_sdist_5efe48d2\":[{\"filename\":\"jeepney-0.8.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "keyring": "{\"rules_python_publish_deps_311_keyring_py3_none_any_5426f817\":[{\"filename\":\"keyring-25.4.1-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_keyring_sdist_b07ebc55\":[{\"filename\":\"keyring-25.4.1.tar.gz\",\"version\":\"3.11\"}]}",
+                "markdown_it_py": "{\"rules_python_publish_deps_311_markdown_it_py_py3_none_any_35521684\":[{\"filename\":\"markdown_it_py-3.0.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_markdown_it_py_sdist_e3f60a94\":[{\"filename\":\"markdown-it-py-3.0.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "mdurl": "{\"rules_python_publish_deps_311_mdurl_py3_none_any_84008a41\":[{\"filename\":\"mdurl-0.1.2-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_mdurl_sdist_bb413d29\":[{\"filename\":\"mdurl-0.1.2.tar.gz\",\"version\":\"3.11\"}]}",
+                "more_itertools": "{\"rules_python_publish_deps_311_more_itertools_py3_none_any_037b0d32\":[{\"filename\":\"more_itertools-10.5.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_more_itertools_sdist_5482bfef\":[{\"filename\":\"more-itertools-10.5.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "nh3": "{\"rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_14c5a72e\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_7b7c2a3c\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_aarch64_42c64511\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_armv7l_0411beb0\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64_5f36b271\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64le_34c03fa7\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_s390x_19aaba96\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_x86_64_de3ceed6\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_aarch64_f0eca9ca\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_armv7l_3a157ab1\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_x86_64_36c95d4b\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_win_amd64_8ce0f819\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-win_amd64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_sdist_94a16692\":[{\"filename\":\"nh3-0.2.18.tar.gz\",\"version\":\"3.11\"}]}",
+                "pkginfo": "{\"rules_python_publish_deps_311_pkginfo_py3_none_any_889a6da2\":[{\"filename\":\"pkginfo-1.10.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_pkginfo_sdist_5df73835\":[{\"filename\":\"pkginfo-1.10.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "pycparser": "{\"rules_python_publish_deps_311_pycparser_py3_none_any_c3702b6d\":[{\"filename\":\"pycparser-2.22-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_pycparser_sdist_491c8be9\":[{\"filename\":\"pycparser-2.22.tar.gz\",\"version\":\"3.11\"}]}",
+                "pygments": "{\"rules_python_publish_deps_311_pygments_py3_none_any_b8e6aca0\":[{\"filename\":\"pygments-2.18.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_pygments_sdist_786ff802\":[{\"filename\":\"pygments-2.18.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "pywin32_ctypes": "{\"rules_python_publish_deps_311_pywin32_ctypes_py3_none_any_8a151337\":[{\"filename\":\"pywin32_ctypes-0.2.3-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_pywin32_ctypes_sdist_d162dc04\":[{\"filename\":\"pywin32-ctypes-0.2.3.tar.gz\",\"version\":\"3.11\"}]}",
+                "readme_renderer": "{\"rules_python_publish_deps_311_readme_renderer_py3_none_any_2fbca89b\":[{\"filename\":\"readme_renderer-44.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_readme_renderer_sdist_8712034e\":[{\"filename\":\"readme_renderer-44.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "requests": "{\"rules_python_publish_deps_311_requests_py3_none_any_70761cfe\":[{\"filename\":\"requests-2.32.3-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_requests_sdist_55365417\":[{\"filename\":\"requests-2.32.3.tar.gz\",\"version\":\"3.11\"}]}",
+                "requests_toolbelt": "{\"rules_python_publish_deps_311_requests_toolbelt_py2_none_any_cccfdd66\":[{\"filename\":\"requests_toolbelt-1.0.0-py2.py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_requests_toolbelt_sdist_7681a0a3\":[{\"filename\":\"requests-toolbelt-1.0.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "rfc3986": "{\"rules_python_publish_deps_311_rfc3986_py2_none_any_50b1502b\":[{\"filename\":\"rfc3986-2.0.0-py2.py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_rfc3986_sdist_97aacf9d\":[{\"filename\":\"rfc3986-2.0.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "rich": "{\"rules_python_publish_deps_311_rich_py3_none_any_9836f509\":[{\"filename\":\"rich-13.9.3-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_rich_sdist_bc1e01b8\":[{\"filename\":\"rich-13.9.3.tar.gz\",\"version\":\"3.11\"}]}",
+                "secretstorage": "{\"rules_python_publish_deps_311_secretstorage_py3_none_any_f356e662\":[{\"filename\":\"SecretStorage-3.3.3-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_secretstorage_sdist_2403533e\":[{\"filename\":\"SecretStorage-3.3.3.tar.gz\",\"version\":\"3.11\"}]}",
+                "twine": "{\"rules_python_publish_deps_311_twine_py3_none_any_215dbe7b\":[{\"filename\":\"twine-5.1.1-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_twine_sdist_9aa08251\":[{\"filename\":\"twine-5.1.1.tar.gz\",\"version\":\"3.11\"}]}",
+                "urllib3": "{\"rules_python_publish_deps_311_urllib3_py3_none_any_ca899ca0\":[{\"filename\":\"urllib3-2.2.3-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_urllib3_sdist_e7d814a8\":[{\"filename\":\"urllib3-2.2.3.tar.gz\",\"version\":\"3.11\"}]}",
+                "zipp": "{\"rules_python_publish_deps_311_zipp_py3_none_any_a817ac80\":[{\"filename\":\"zipp-3.20.2-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_zipp_sdist_bc9eb26f\":[{\"filename\":\"zipp-3.20.2.tar.gz\",\"version\":\"3.11\"}]}"
               },
-              "default_version": "3.11",
+              "packages": [
+                "backports_tarfile",
+                "certifi",
+                "charset_normalizer",
+                "docutils",
+                "idna",
+                "importlib_metadata",
+                "jaraco_classes",
+                "jaraco_context",
+                "jaraco_functools",
+                "keyring",
+                "markdown_it_py",
+                "mdurl",
+                "more_itertools",
+                "nh3",
+                "pkginfo",
+                "pygments",
+                "readme_renderer",
+                "requests",
+                "requests_toolbelt",
+                "rfc3986",
+                "rich",
+                "twine",
+                "urllib3",
+                "zipp"
+              ],
               "groups": {}
             }
           }
+        },
+        "moduleExtensionMetadata": {
+          "useAllRepos": "NO",
+          "reproducible": false
         },
         "recordedRepoMappingEntries": [
           [
@@ -2836,6 +3956,14289 @@
             "rules_python~~python~pythons_hub",
             "python_3_9_host",
             "rules_python~~python~python_3_9_host"
+          ]
+        ]
+      }
+    },
+    "@@rules_rust~//crate_universe/private/module_extensions:cargo_bazel_bootstrap.bzl%cargo_bazel_bootstrap": {
+      "general": {
+        "bzlTransitiveDigest": "5rGu4OMmO34EEu1ZdsFFZdtotelPu3AI/LgVtJUTElM=",
+        "usagesDigest": "4tKJUXvKsOrd24J4lhDQ1SWU/l5Xakzx7FaMm1RkMZw=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "cargo_bazel_bootstrap": {
+            "bzlFile": "@@rules_rust~//cargo/private:cargo_bootstrap.bzl",
+            "ruleClassName": "cargo_bootstrap_repository",
+            "attributes": {
+              "srcs": [
+                "@@rules_rust~//crate_universe:src/api.rs",
+                "@@rules_rust~//crate_universe:src/api/lockfile.rs",
+                "@@rules_rust~//crate_universe:src/cli.rs",
+                "@@rules_rust~//crate_universe:src/cli/generate.rs",
+                "@@rules_rust~//crate_universe:src/cli/query.rs",
+                "@@rules_rust~//crate_universe:src/cli/splice.rs",
+                "@@rules_rust~//crate_universe:src/cli/vendor.rs",
+                "@@rules_rust~//crate_universe:src/config.rs",
+                "@@rules_rust~//crate_universe:src/context.rs",
+                "@@rules_rust~//crate_universe:src/context/crate_context.rs",
+                "@@rules_rust~//crate_universe:src/context/platforms.rs",
+                "@@rules_rust~//crate_universe:src/lib.rs",
+                "@@rules_rust~//crate_universe:src/lockfile.rs",
+                "@@rules_rust~//crate_universe:src/main.rs",
+                "@@rules_rust~//crate_universe:src/metadata.rs",
+                "@@rules_rust~//crate_universe:src/metadata/cargo_bin.rs",
+                "@@rules_rust~//crate_universe:src/metadata/cargo_tree_resolver.rs",
+                "@@rules_rust~//crate_universe:src/metadata/cargo_tree_rustc_wrapper.bat",
+                "@@rules_rust~//crate_universe:src/metadata/cargo_tree_rustc_wrapper.sh",
+                "@@rules_rust~//crate_universe:src/metadata/dependency.rs",
+                "@@rules_rust~//crate_universe:src/metadata/metadata_annotation.rs",
+                "@@rules_rust~//crate_universe:src/rendering.rs",
+                "@@rules_rust~//crate_universe:src/rendering/template_engine.rs",
+                "@@rules_rust~//crate_universe:src/rendering/templates/module_bzl.j2",
+                "@@rules_rust~//crate_universe:src/rendering/templates/partials/header.j2",
+                "@@rules_rust~//crate_universe:src/rendering/templates/partials/module/aliases_map.j2",
+                "@@rules_rust~//crate_universe:src/rendering/templates/partials/module/deps_map.j2",
+                "@@rules_rust~//crate_universe:src/rendering/templates/partials/module/repo_git.j2",
+                "@@rules_rust~//crate_universe:src/rendering/templates/partials/module/repo_http.j2",
+                "@@rules_rust~//crate_universe:src/rendering/templates/vendor_module.j2",
+                "@@rules_rust~//crate_universe:src/rendering/verbatim/alias_rules.bzl",
+                "@@rules_rust~//crate_universe:src/select.rs",
+                "@@rules_rust~//crate_universe:src/splicing.rs",
+                "@@rules_rust~//crate_universe:src/splicing/cargo_config.rs",
+                "@@rules_rust~//crate_universe:src/splicing/crate_index_lookup.rs",
+                "@@rules_rust~//crate_universe:src/splicing/splicer.rs",
+                "@@rules_rust~//crate_universe:src/test.rs",
+                "@@rules_rust~//crate_universe:src/utils.rs",
+                "@@rules_rust~//crate_universe:src/utils/starlark.rs",
+                "@@rules_rust~//crate_universe:src/utils/starlark/glob.rs",
+                "@@rules_rust~//crate_universe:src/utils/starlark/label.rs",
+                "@@rules_rust~//crate_universe:src/utils/starlark/select.rs",
+                "@@rules_rust~//crate_universe:src/utils/starlark/select_dict.rs",
+                "@@rules_rust~//crate_universe:src/utils/starlark/select_list.rs",
+                "@@rules_rust~//crate_universe:src/utils/starlark/select_scalar.rs",
+                "@@rules_rust~//crate_universe:src/utils/starlark/select_set.rs",
+                "@@rules_rust~//crate_universe:src/utils/starlark/serialize.rs",
+                "@@rules_rust~//crate_universe:src/utils/starlark/target_compatible_with.rs",
+                "@@rules_rust~//crate_universe:src/utils/symlink.rs",
+                "@@rules_rust~//crate_universe:src/utils/target_triple.rs"
+              ],
+              "binary": "cargo-bazel",
+              "cargo_lockfile": "@@rules_rust~//crate_universe:Cargo.lock",
+              "cargo_toml": "@@rules_rust~//crate_universe:Cargo.toml",
+              "version": "1.81.0",
+              "timeout": 900,
+              "rust_toolchain_cargo_template": "@rust_host_tools//:bin/{tool}",
+              "rust_toolchain_rustc_template": "@rust_host_tools//:bin/{tool}"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_rust~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "rules_rust~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_rust~",
+            "rules_cc",
+            "rules_cc~"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust",
+            "rules_rust~"
+          ]
+        ]
+      }
+    },
+    "@@rules_rust~//rust:extensions.bzl%rust": {
+      "general": {
+        "bzlTransitiveDigest": "/zeRQSYjxktrZUKOxoFuoSZAk2yrQ9tfusHJfHLgBCM=",
+        "usagesDigest": "p3vlEY5e6iHCg9d0OSqN8SPxiXdJFxI1wg1MKecojvs=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rust_analyzer_1.81.0_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_analyzer_toolchain_tools_repository",
+            "attributes": {
+              "version": "1.81.0",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_analyzer_1.81.0": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_analyzer_1.81.0_tools//:rust_analyzer_toolchain",
+              "toolchain_type": "@rules_rust//rust/rust_analyzer:toolchain_type",
+              "exec_compatible_with": [],
+              "target_compatible_with": []
+            }
+          },
+          "rust_darwin_aarch64__aarch64-apple-darwin__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-apple-darwin",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__aarch64-apple-darwin__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__aarch64-apple-darwin__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-apple-darwin",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__aarch64-apple-darwin__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__aarch64-apple-darwin__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__wasm32-unknown-unknown__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__wasm32-unknown-unknown__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__wasm32-wasi__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__wasm32-wasi__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__wasm32-wasi__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__wasm32-wasi__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_darwin_aarch64": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_darwin_aarch64__aarch64-apple-darwin__stable//:toolchain",
+                "@rust_darwin_aarch64__aarch64-apple-darwin__nightly//:toolchain",
+                "@rust_darwin_aarch64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_darwin_aarch64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_darwin_aarch64__wasm32-wasi__stable//:toolchain",
+                "@rust_darwin_aarch64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-apple-darwin_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "aarch64-apple-darwin"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__aarch64-apple-darwin_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-pc-windows-msvc",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ]
+            }
+          },
+          "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-pc-windows-msvc",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__aarch64-pc-windows-msvc__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ]
+            }
+          },
+          "rust_windows_aarch64__wasm32-unknown-unknown__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__wasm32-unknown-unknown__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_windows_aarch64__wasm32-unknown-unknown__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__wasm32-unknown-unknown__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_windows_aarch64__wasm32-wasi__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__wasm32-wasi__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_windows_aarch64__wasm32-wasi__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__wasm32-wasi__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_windows_aarch64": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable//:toolchain",
+                "@rust_windows_aarch64__aarch64-pc-windows-msvc__nightly//:toolchain",
+                "@rust_windows_aarch64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_windows_aarch64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_windows_aarch64__wasm32-wasi__stable//:toolchain",
+                "@rust_windows_aarch64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "aarch64-pc-windows-msvc"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-unknown-linux-gnu",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-unknown-linux-gnu",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_aarch64__wasm32-unknown-unknown__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__wasm32-unknown-unknown__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_aarch64__wasm32-unknown-unknown__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__wasm32-unknown-unknown__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_aarch64__wasm32-wasi__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__wasm32-wasi__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_aarch64__wasm32-wasi__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__wasm32-wasi__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_aarch64": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable//:toolchain",
+                "@rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly//:toolchain",
+                "@rust_linux_aarch64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_linux_aarch64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_linux_aarch64__wasm32-wasi__stable//:toolchain",
+                "@rust_linux_aarch64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "aarch64-unknown-linux-gnu"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_linux_s390x__s390x-unknown-linux-gnu__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "s390x-unknown-linux-gnu",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__s390x-unknown-linux-gnu__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__s390x-unknown-linux-gnu__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_s390x__s390x-unknown-linux-gnu__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "s390x-unknown-linux-gnu",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__s390x-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_s390x__wasm32-unknown-unknown__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__wasm32-unknown-unknown__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_s390x__wasm32-unknown-unknown__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__wasm32-unknown-unknown__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_s390x__wasm32-wasi__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__wasm32-wasi__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_s390x__wasm32-wasi__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__wasm32-wasi__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_s390x": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_linux_s390x__s390x-unknown-linux-gnu__stable//:toolchain",
+                "@rust_linux_s390x__s390x-unknown-linux-gnu__nightly//:toolchain",
+                "@rust_linux_s390x__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_linux_s390x__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_linux_s390x__wasm32-wasi__stable//:toolchain",
+                "@rust_linux_s390x__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "s390x-unknown-linux-gnu"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_darwin_x86_64__x86_64-apple-darwin__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-apple-darwin",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__x86_64-apple-darwin__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__x86_64-apple-darwin__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-apple-darwin",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__x86_64-apple-darwin__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__x86_64-apple-darwin__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__wasm32-unknown-unknown__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__wasm32-unknown-unknown__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__wasm32-wasi__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__wasm32-wasi__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__wasm32-wasi__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__wasm32-wasi__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_darwin_x86_64": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_darwin_x86_64__x86_64-apple-darwin__stable//:toolchain",
+                "@rust_darwin_x86_64__x86_64-apple-darwin__nightly//:toolchain",
+                "@rust_darwin_x86_64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_darwin_x86_64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_darwin_x86_64__wasm32-wasi__stable//:toolchain",
+                "@rust_darwin_x86_64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-apple-darwin_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "x86_64-apple-darwin"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__x86_64-apple-darwin_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-pc-windows-msvc",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ]
+            }
+          },
+          "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-pc-windows-msvc",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__x86_64-pc-windows-msvc__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ]
+            }
+          },
+          "rust_windows_x86_64__wasm32-unknown-unknown__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__wasm32-unknown-unknown__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_windows_x86_64__wasm32-unknown-unknown__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__wasm32-unknown-unknown__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_windows_x86_64__wasm32-wasi__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__wasm32-wasi__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_windows_x86_64__wasm32-wasi__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__wasm32-wasi__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_windows_x86_64": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable//:toolchain",
+                "@rust_windows_x86_64__x86_64-pc-windows-msvc__nightly//:toolchain",
+                "@rust_windows_x86_64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_windows_x86_64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_windows_x86_64__wasm32-wasi__stable//:toolchain",
+                "@rust_windows_x86_64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "x86_64-pc-windows-msvc"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-unknown-freebsd",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-unknown-freebsd",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-wasi__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-wasi__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-wasi__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-wasi__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable//:toolchain",
+                "@rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly//:toolchain",
+                "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_freebsd_x86_64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_freebsd_x86_64__wasm32-wasi__stable//:toolchain",
+                "@rust_freebsd_x86_64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "x86_64-unknown-freebsd"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-unknown-linux-gnu",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-unknown-linux-gnu",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_x86_64__wasm32-unknown-unknown__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__wasm32-unknown-unknown__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_x86_64__wasm32-unknown-unknown__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__wasm32-unknown-unknown__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_x86_64__wasm32-wasi__stable_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__wasm32-wasi__stable": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_x86_64__wasm32-wasi__nightly_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__wasm32-wasi__nightly": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_x86_64": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable//:toolchain",
+                "@rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly//:toolchain",
+                "@rust_linux_x86_64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_linux_x86_64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_linux_x86_64__wasm32-wasi__stable//:toolchain",
+                "@rust_linux_x86_64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "x86_64-unknown-linux-gnu"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_toolchains": {
+            "bzlFile": "@@rules_rust~//rust/private:repository_utils.bzl",
+            "ruleClassName": "toolchain_repository_hub",
+            "attributes": {
+              "toolchain_names": [
+                "rust_analyzer_1.81.0",
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable",
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly",
+                "rust_darwin_aarch64__wasm32-wasi__stable",
+                "rust_darwin_aarch64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly",
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable",
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly",
+                "rust_windows_aarch64__wasm32-wasi__stable",
+                "rust_windows_aarch64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly",
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable",
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly",
+                "rust_linux_aarch64__wasm32-wasi__stable",
+                "rust_linux_aarch64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly",
+                "rust_linux_s390x__wasm32-unknown-unknown__stable",
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly",
+                "rust_linux_s390x__wasm32-wasi__stable",
+                "rust_linux_s390x__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu",
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable",
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly",
+                "rust_darwin_x86_64__wasm32-wasi__stable",
+                "rust_darwin_x86_64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly",
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable",
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly",
+                "rust_windows_x86_64__wasm32-wasi__stable",
+                "rust_windows_x86_64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly",
+                "rust_freebsd_x86_64__wasm32-wasi__stable",
+                "rust_freebsd_x86_64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly",
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable",
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly",
+                "rust_linux_x86_64__wasm32-wasi__stable",
+                "rust_linux_x86_64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu"
+              ],
+              "toolchain_labels": {
+                "rust_analyzer_1.81.0": "@rust_analyzer_1.81.0_tools//:rust_analyzer_toolchain",
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:rust_toolchain",
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": "@rust_darwin_aarch64__aarch64-apple-darwin__nightly_tools//:rust_toolchain",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": "@rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": "@rust_darwin_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_darwin_aarch64__wasm32-wasi__stable": "@rust_darwin_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_darwin_aarch64__wasm32-wasi__nightly": "@rust_darwin_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": "@rustfmt_nightly-2024-09-05__aarch64-apple-darwin_tools//:rustfmt_toolchain",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools//:rust_toolchain",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": "@rust_windows_aarch64__aarch64-pc-windows-msvc__nightly_tools//:rust_toolchain",
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable": "@rust_windows_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly": "@rust_windows_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_windows_aarch64__wasm32-wasi__stable": "@rust_windows_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_windows_aarch64__wasm32-wasi__nightly": "@rust_windows_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": "@rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable": "@rust_linux_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly": "@rust_linux_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_linux_aarch64__wasm32-wasi__stable": "@rust_linux_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_linux_aarch64__wasm32-wasi__nightly": "@rust_linux_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": "@rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": "@rust_linux_s390x__s390x-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": "@rust_linux_s390x__s390x-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_linux_s390x__wasm32-unknown-unknown__stable": "@rust_linux_s390x__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly": "@rust_linux_s390x__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_linux_s390x__wasm32-wasi__stable": "@rust_linux_s390x__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_linux_s390x__wasm32-wasi__nightly": "@rust_linux_s390x__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": "@rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu_tools//:rustfmt_toolchain",
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:rust_toolchain",
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": "@rust_darwin_x86_64__x86_64-apple-darwin__nightly_tools//:rust_toolchain",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": "@rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": "@rust_darwin_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_darwin_x86_64__wasm32-wasi__stable": "@rust_darwin_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_darwin_x86_64__wasm32-wasi__nightly": "@rust_darwin_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": "@rustfmt_nightly-2024-09-05__x86_64-apple-darwin_tools//:rustfmt_toolchain",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools//:rust_toolchain",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": "@rust_windows_x86_64__x86_64-pc-windows-msvc__nightly_tools//:rust_toolchain",
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable": "@rust_windows_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly": "@rust_windows_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_windows_x86_64__wasm32-wasi__stable": "@rust_windows_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_windows_x86_64__wasm32-wasi__nightly": "@rust_windows_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": "@rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": "@rust_freebsd_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__wasm32-wasi__stable": "@rust_freebsd_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__wasm32-wasi__nightly": "@rust_freebsd_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": "@rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable": "@rust_linux_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly": "@rust_linux_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_linux_x86_64__wasm32-wasi__stable": "@rust_linux_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_linux_x86_64__wasm32-wasi__nightly": "@rust_linux_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": "@rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain"
+              },
+              "toolchain_types": {
+                "rust_analyzer_1.81.0": "@rules_rust//rust/rust_analyzer:toolchain_type",
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type"
+              },
+              "exec_compatible_with": {
+                "rust_analyzer_1.81.0": [],
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-wasi__stable": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-wasi__nightly": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ]
+              },
+              "target_compatible_with": {
+                "rust_analyzer_1.81.0": [],
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_darwin_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_darwin_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": [],
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_windows_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_windows_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": [],
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_linux_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": [],
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_s390x__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_linux_s390x__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": [],
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_darwin_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_darwin_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": [],
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_windows_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_windows_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": [],
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_freebsd_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_freebsd_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": [],
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_linux_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": []
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features~",
+            "bazel_features_globals",
+            "bazel_features~~version_extension~bazel_features_globals"
+          ],
+          [
+            "bazel_features~",
+            "bazel_features_version",
+            "bazel_features~~version_extension~bazel_features_version"
+          ],
+          [
+            "rules_rust~",
+            "bazel_features",
+            "bazel_features~"
+          ],
+          [
+            "rules_rust~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "rules_rust~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust",
+            "rules_rust~"
+          ]
+        ]
+      }
+    },
+    "@@rules_rust~//rust/private:extensions.bzl%i": {
+      "general": {
+        "bzlTransitiveDigest": "boVqwfKlg8l1BbgzETWA/L8vPkFNANyfX5gr9HUPlaY=",
+        "usagesDigest": "ARQAB02XnB2xam5OJMZpyHooYba5je4Frg/SGvy4AxY=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rules_rust_tinyjson": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9ab95735ea2c8fd51154d01e39cf13912a78071c2d89abc49a7ef102a7dd725a",
+              "url": "https://static.crates.io/crates/tinyjson/tinyjson-2.5.1.crate",
+              "strip_prefix": "tinyjson-2.5.1",
+              "type": "tar.gz",
+              "build_file": "@@rules_rust~//util/process_wrapper:BUILD.tinyjson.bazel"
+            }
+          },
+          "cui": {
+            "bzlFile": "@@rules_rust~//crate_universe/private:crates_vendor.bzl",
+            "ruleClassName": "crates_vendor_remote_repository",
+            "attributes": {
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bazel",
+              "defs_module": "@@rules_rust~//crate_universe/3rdparty/crates:defs.bzl"
+            }
+          },
+          "cui__adler-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/adler/1.0.2/download"
+              ],
+              "strip_prefix": "adler-1.0.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.adler-1.0.2.bazel"
+            }
+          },
+          "cui__aho-corasick-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
+              ],
+              "strip_prefix": "aho-corasick-1.0.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
+            }
+          },
+          "cui__android-tzdata-0.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/android-tzdata/0.1.1/download"
+              ],
+              "strip_prefix": "android-tzdata-0.1.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.android-tzdata-0.1.1.bazel"
+            }
+          },
+          "cui__android_system_properties-0.1.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/android_system_properties/0.1.5/download"
+              ],
+              "strip_prefix": "android_system_properties-0.1.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.android_system_properties-0.1.5.bazel"
+            }
+          },
+          "cui__anstream-0.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstream/0.3.2/download"
+              ],
+              "strip_prefix": "anstream-0.3.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstream-0.3.2.bazel"
+            }
+          },
+          "cui__anstyle-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle/1.0.1/download"
+              ],
+              "strip_prefix": "anstyle-1.0.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstyle-1.0.1.bazel"
+            }
+          },
+          "cui__anstyle-parse-0.2.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-parse/0.2.1/download"
+              ],
+              "strip_prefix": "anstyle-parse-0.2.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstyle-parse-0.2.1.bazel"
+            }
+          },
+          "cui__anstyle-query-1.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-query/1.0.0/download"
+              ],
+              "strip_prefix": "anstyle-query-1.0.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstyle-query-1.0.0.bazel"
+            }
+          },
+          "cui__anstyle-wincon-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-wincon/1.0.1/download"
+              ],
+              "strip_prefix": "anstyle-wincon-1.0.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstyle-wincon-1.0.1.bazel"
+            }
+          },
+          "cui__anyhow-1.0.75": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.75/download"
+              ],
+              "strip_prefix": "anyhow-1.0.75",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anyhow-1.0.75.bazel"
+            }
+          },
+          "cui__arc-swap-1.6.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/arc-swap/1.6.0/download"
+              ],
+              "strip_prefix": "arc-swap-1.6.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.arc-swap-1.6.0.bazel"
+            }
+          },
+          "cui__arrayvec-0.7.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/arrayvec/0.7.4/download"
+              ],
+              "strip_prefix": "arrayvec-0.7.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.arrayvec-0.7.4.bazel"
+            }
+          },
+          "cui__autocfg-1.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
+              ],
+              "strip_prefix": "autocfg-1.1.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
+            }
+          },
+          "cui__bitflags-1.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
+              ],
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
+            }
+          },
+          "cui__bitflags-2.4.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/2.4.1/download"
+              ],
+              "strip_prefix": "bitflags-2.4.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bitflags-2.4.1.bazel"
+            }
+          },
+          "cui__block-buffer-0.10.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/block-buffer/0.10.4/download"
+              ],
+              "strip_prefix": "block-buffer-0.10.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.block-buffer-0.10.4.bazel"
+            }
+          },
+          "cui__bstr-1.6.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bstr/1.6.0/download"
+              ],
+              "strip_prefix": "bstr-1.6.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bstr-1.6.0.bazel"
+            }
+          },
+          "cui__btoi-0.4.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/btoi/0.4.3/download"
+              ],
+              "strip_prefix": "btoi-0.4.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.btoi-0.4.3.bazel"
+            }
+          },
+          "cui__bumpalo-3.13.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bumpalo/3.13.0/download"
+              ],
+              "strip_prefix": "bumpalo-3.13.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bumpalo-3.13.0.bazel"
+            }
+          },
+          "cui__byteyarn-0.2.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a7534301c0ea17abb4db06d75efc7b4b0fa360fce8e175a4330d721c71c942ff",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/byteyarn/0.2.3/download"
+              ],
+              "strip_prefix": "byteyarn-0.2.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.byteyarn-0.2.3.bazel"
+            }
+          },
+          "cui__camino-1.1.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/camino/1.1.6/download"
+              ],
+              "strip_prefix": "camino-1.1.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.camino-1.1.6.bazel"
+            }
+          },
+          "cui__cargo-lock-9.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e11c675378efb449ed3ce8de78d75d0d80542fc98487c26aba28eb3b82feac72",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo-lock/9.0.0/download"
+              ],
+              "strip_prefix": "cargo-lock-9.0.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo-lock-9.0.0.bazel"
+            }
+          },
+          "cui__cargo-platform-0.1.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "12024c4645c97566567129c204f65d5815a8c9aecf30fcbe682b2fe034996d36",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo-platform/0.1.4/download"
+              ],
+              "strip_prefix": "cargo-platform-0.1.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo-platform-0.1.4.bazel"
+            }
+          },
+          "cui__cargo_metadata-0.18.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo_metadata/0.18.1/download"
+              ],
+              "strip_prefix": "cargo_metadata-0.18.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo_metadata-0.18.1.bazel"
+            }
+          },
+          "cui__cargo_toml-0.19.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo_toml/0.19.2/download"
+              ],
+              "strip_prefix": "cargo_toml-0.19.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo_toml-0.19.2.bazel"
+            }
+          },
+          "cui__cc-1.0.79": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cc/1.0.79/download"
+              ],
+              "strip_prefix": "cc-1.0.79",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cc-1.0.79.bazel"
+            }
+          },
+          "cui__cfg-expr-0.15.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "03915af431787e6ffdcc74c645077518c6b6e01f80b761e0fbbfa288536311b3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-expr/0.15.5/download"
+              ],
+              "strip_prefix": "cfg-expr-0.15.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cfg-expr-0.15.5.bazel"
+            }
+          },
+          "cui__cfg-if-1.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "cui__chrono-0.4.26": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/chrono/0.4.26/download"
+              ],
+              "strip_prefix": "chrono-0.4.26",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.chrono-0.4.26.bazel"
+            }
+          },
+          "cui__chrono-tz-0.8.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e23185c0e21df6ed832a12e2bda87c7d1def6842881fb634a8511ced741b0d76",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/chrono-tz/0.8.4/download"
+              ],
+              "strip_prefix": "chrono-tz-0.8.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.chrono-tz-0.8.4.bazel"
+            }
+          },
+          "cui__chrono-tz-build-0.2.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/chrono-tz-build/0.2.1/download"
+              ],
+              "strip_prefix": "chrono-tz-build-0.2.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.chrono-tz-build-0.2.1.bazel"
+            }
+          },
+          "cui__clap-4.3.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap/4.3.11/download"
+              ],
+              "strip_prefix": "clap-4.3.11",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clap-4.3.11.bazel"
+            }
+          },
+          "cui__clap_builder-4.3.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_builder/4.3.11/download"
+              ],
+              "strip_prefix": "clap_builder-4.3.11",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clap_builder-4.3.11.bazel"
+            }
+          },
+          "cui__clap_derive-4.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_derive/4.3.2/download"
+              ],
+              "strip_prefix": "clap_derive-4.3.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clap_derive-4.3.2.bazel"
+            }
+          },
+          "cui__clap_lex-0.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_lex/0.5.0/download"
+              ],
+              "strip_prefix": "clap_lex-0.5.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clap_lex-0.5.0.bazel"
+            }
+          },
+          "cui__clru-0.6.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clru/0.6.1/download"
+              ],
+              "strip_prefix": "clru-0.6.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clru-0.6.1.bazel"
+            }
+          },
+          "cui__colorchoice-1.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/colorchoice/1.0.0/download"
+              ],
+              "strip_prefix": "colorchoice-1.0.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.colorchoice-1.0.0.bazel"
+            }
+          },
+          "cui__core-foundation-sys-0.8.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/core-foundation-sys/0.8.4/download"
+              ],
+              "strip_prefix": "core-foundation-sys-0.8.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.core-foundation-sys-0.8.4.bazel"
+            }
+          },
+          "cui__cpufeatures-0.2.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cpufeatures/0.2.9/download"
+              ],
+              "strip_prefix": "cpufeatures-0.2.9",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cpufeatures-0.2.9.bazel"
+            }
+          },
+          "cui__crates-index-2.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "33bc10579ea08741ae173928194b6c42c90b295d51ddd0d18238eaf15502ac87",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crates-index/2.2.0/download"
+              ],
+              "strip_prefix": "crates-index-2.2.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crates-index-2.2.0.bazel"
+            }
+          },
+          "cui__crc32fast-1.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crc32fast/1.3.2/download"
+              ],
+              "strip_prefix": "crc32fast-1.3.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crc32fast-1.3.2.bazel"
+            }
+          },
+          "cui__crossbeam-0.8.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam/0.8.2/download"
+              ],
+              "strip_prefix": "crossbeam-0.8.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-0.8.2.bazel"
+            }
+          },
+          "cui__crossbeam-channel-0.5.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-channel/0.5.8/download"
+              ],
+              "strip_prefix": "crossbeam-channel-0.5.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-channel-0.5.8.bazel"
+            }
+          },
+          "cui__crossbeam-deque-0.8.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-deque/0.8.3/download"
+              ],
+              "strip_prefix": "crossbeam-deque-0.8.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-deque-0.8.3.bazel"
+            }
+          },
+          "cui__crossbeam-epoch-0.9.15": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-epoch/0.9.15/download"
+              ],
+              "strip_prefix": "crossbeam-epoch-0.9.15",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-epoch-0.9.15.bazel"
+            }
+          },
+          "cui__crossbeam-queue-0.3.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-queue/0.3.8/download"
+              ],
+              "strip_prefix": "crossbeam-queue-0.3.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-queue-0.3.8.bazel"
+            }
+          },
+          "cui__crossbeam-utils-0.8.16": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-utils/0.8.16/download"
+              ],
+              "strip_prefix": "crossbeam-utils-0.8.16",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-utils-0.8.16.bazel"
+            }
+          },
+          "cui__crypto-common-0.1.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crypto-common/0.1.6/download"
+              ],
+              "strip_prefix": "crypto-common-0.1.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crypto-common-0.1.6.bazel"
+            }
+          },
+          "cui__deranged-0.3.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/deranged/0.3.9/download"
+              ],
+              "strip_prefix": "deranged-0.3.9",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.deranged-0.3.9.bazel"
+            }
+          },
+          "cui__deunicode-0.4.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/deunicode/0.4.3/download"
+              ],
+              "strip_prefix": "deunicode-0.4.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.deunicode-0.4.3.bazel"
+            }
+          },
+          "cui__digest-0.10.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/digest/0.10.7/download"
+              ],
+              "strip_prefix": "digest-0.10.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.digest-0.10.7.bazel"
+            }
+          },
+          "cui__dunce-1.0.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/dunce/1.0.4/download"
+              ],
+              "strip_prefix": "dunce-1.0.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.dunce-1.0.4.bazel"
+            }
+          },
+          "cui__either-1.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.9.0/download"
+              ],
+              "strip_prefix": "either-1.9.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.either-1.9.0.bazel"
+            }
+          },
+          "cui__encoding_rs-0.8.33": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/encoding_rs/0.8.33/download"
+              ],
+              "strip_prefix": "encoding_rs-0.8.33",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.encoding_rs-0.8.33.bazel"
+            }
+          },
+          "cui__equivalent-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/equivalent/1.0.1/download"
+              ],
+              "strip_prefix": "equivalent-1.0.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
+            }
+          },
+          "cui__errno-0.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno/0.3.1/download"
+              ],
+              "strip_prefix": "errno-0.3.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.errno-0.3.1.bazel"
+            }
+          },
+          "cui__errno-dragonfly-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
+              ],
+              "strip_prefix": "errno-dragonfly-0.1.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
+            }
+          },
+          "cui__faster-hex-0.8.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "239f7bfb930f820ab16a9cd95afc26f88264cf6905c960b340a615384aa3338a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/faster-hex/0.8.1/download"
+              ],
+              "strip_prefix": "faster-hex-0.8.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.faster-hex-0.8.1.bazel"
+            }
+          },
+          "cui__fastrand-2.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fastrand/2.0.1/download"
+              ],
+              "strip_prefix": "fastrand-2.0.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.fastrand-2.0.1.bazel"
+            }
+          },
+          "cui__filetime-0.2.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/filetime/0.2.22/download"
+              ],
+              "strip_prefix": "filetime-0.2.22",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.filetime-0.2.22.bazel"
+            }
+          },
+          "cui__flate2-1.0.28": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/flate2/1.0.28/download"
+              ],
+              "strip_prefix": "flate2-1.0.28",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.flate2-1.0.28.bazel"
+            }
+          },
+          "cui__fnv-1.0.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fnv/1.0.7/download"
+              ],
+              "strip_prefix": "fnv-1.0.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
+            }
+          },
+          "cui__form_urlencoded-1.2.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/form_urlencoded/1.2.1/download"
+              ],
+              "strip_prefix": "form_urlencoded-1.2.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.form_urlencoded-1.2.1.bazel"
+            }
+          },
+          "cui__fuchsia-cprng-0.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fuchsia-cprng/0.1.1/download"
+              ],
+              "strip_prefix": "fuchsia-cprng-0.1.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.fuchsia-cprng-0.1.1.bazel"
+            }
+          },
+          "cui__generic-array-0.14.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/generic-array/0.14.7/download"
+              ],
+              "strip_prefix": "generic-array-0.14.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.generic-array-0.14.7.bazel"
+            }
+          },
+          "cui__getrandom-0.2.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/getrandom/0.2.10/download"
+              ],
+              "strip_prefix": "getrandom-0.2.10",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.getrandom-0.2.10.bazel"
+            }
+          },
+          "cui__gix-0.54.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ad6d32e74454459690d57d18ea4ebec1629936e6b130b51d12cb4a81630ac953",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix/0.54.1/download"
+              ],
+              "strip_prefix": "gix-0.54.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-0.54.1.bazel"
+            }
+          },
+          "cui__gix-actor-0.27.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "08c60e982c5290897122d4e2622447f014a2dadd5a18cb73d50bb91b31645e27",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-actor/0.27.0/download"
+              ],
+              "strip_prefix": "gix-actor-0.27.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-actor-0.27.0.bazel"
+            }
+          },
+          "cui__gix-attributes-0.19.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2451665e70709ba4753b623ef97511ee98c4a73816b2c5b5df25678d607ed820",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-attributes/0.19.0/download"
+              ],
+              "strip_prefix": "gix-attributes-0.19.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-attributes-0.19.0.bazel"
+            }
+          },
+          "cui__gix-bitmap-0.2.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0ccab4bc576844ddb51b78d81b4a42d73e6229660fa614dfc3d3999c874d1959",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-bitmap/0.2.7/download"
+              ],
+              "strip_prefix": "gix-bitmap-0.2.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-bitmap-0.2.7.bazel"
+            }
+          },
+          "cui__gix-chunk-0.4.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5b42ea64420f7994000130328f3c7a2038f639120518870436d31b8bde704493",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-chunk/0.4.4/download"
+              ],
+              "strip_prefix": "gix-chunk-0.4.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-chunk-0.4.4.bazel"
+            }
+          },
+          "cui__gix-command-0.2.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3c576cfbf577f72c097b5f88aedea502cd62952bdc1fb3adcab4531d5525a4c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-command/0.2.10/download"
+              ],
+              "strip_prefix": "gix-command-0.2.10",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-command-0.2.10.bazel"
+            }
+          },
+          "cui__gix-commitgraph-0.21.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e75a975ee22cf0a002bfe9b5d5cb3d2a88e263a8a178cd7509133cff10f4df8a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-commitgraph/0.21.0/download"
+              ],
+              "strip_prefix": "gix-commitgraph-0.21.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-commitgraph-0.21.0.bazel"
+            }
+          },
+          "cui__gix-config-0.30.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c171514b40487d3f677ae37efc0f45ac980e3169f23c27eb30a70b47fdf88ab5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-config/0.30.0/download"
+              ],
+              "strip_prefix": "gix-config-0.30.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-config-0.30.0.bazel"
+            }
+          },
+          "cui__gix-config-value-0.14.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ea7505b97f4d8e7933e29735a568ba2f86d8de466669d9f0e8321384f9972f47",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-config-value/0.14.0/download"
+              ],
+              "strip_prefix": "gix-config-value-0.14.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-config-value-0.14.0.bazel"
+            }
+          },
+          "cui__gix-credentials-0.20.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "46900b884cc5af6a6c141ee741607c0c651a4e1d33614b8d888a1ba81cc0bc8a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-credentials/0.20.0/download"
+              ],
+              "strip_prefix": "gix-credentials-0.20.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-credentials-0.20.0.bazel"
+            }
+          },
+          "cui__gix-date-0.8.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fc7df669639582dc7c02737642f76890b03b5544e141caba68a7d6b4eb551e0d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-date/0.8.0/download"
+              ],
+              "strip_prefix": "gix-date-0.8.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-date-0.8.0.bazel"
+            }
+          },
+          "cui__gix-diff-0.36.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "788ddb152c388206e81f36bcbb574e7ed7827c27d8fa62227b34edc333d8928c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-diff/0.36.0/download"
+              ],
+              "strip_prefix": "gix-diff-0.36.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-diff-0.36.0.bazel"
+            }
+          },
+          "cui__gix-discover-0.25.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "69507643d75a0ea9a402fcf73ced517d2b95cc95385904ac09d03e0b952fde33",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-discover/0.25.0/download"
+              ],
+              "strip_prefix": "gix-discover-0.25.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-discover-0.25.0.bazel"
+            }
+          },
+          "cui__gix-features-0.35.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9b9ff423ae4983f762659040d13dd7a5defbd54b6a04ac3cc7347741cec828cd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-features/0.35.0/download"
+              ],
+              "strip_prefix": "gix-features-0.35.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-features-0.35.0.bazel"
+            }
+          },
+          "cui__gix-filter-0.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1be40d28cd41445bb6cd52c4d847d915900e5466f7433eaee6a9e0a3d1d88b08",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-filter/0.5.0/download"
+              ],
+              "strip_prefix": "gix-filter-0.5.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-filter-0.5.0.bazel"
+            }
+          },
+          "cui__gix-fs-0.7.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "09815faba62fe9b32d918b75a554686c98e43f7d48c43a80df58eb718e5c6635",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-fs/0.7.0/download"
+              ],
+              "strip_prefix": "gix-fs-0.7.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-fs-0.7.0.bazel"
+            }
+          },
+          "cui__gix-glob-0.13.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a9d76e85f11251dcf751d2c5e918a14f562db5be6f727fd24775245653e9b19d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-glob/0.13.0/download"
+              ],
+              "strip_prefix": "gix-glob-0.13.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-glob-0.13.0.bazel"
+            }
+          },
+          "cui__gix-hash-0.13.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1884c7b41ea0875217c1be9ce91322f90bde433e91d374d0e1276073a51ccc60",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-hash/0.13.1/download"
+              ],
+              "strip_prefix": "gix-hash-0.13.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-hash-0.13.1.bazel"
+            }
+          },
+          "cui__gix-hashtable-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "409268480841ad008e81c17ca5a293393fbf9f2b6c2f85b8ab9de1f0c5176a16",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-hashtable/0.4.0/download"
+              ],
+              "strip_prefix": "gix-hashtable-0.4.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-hashtable-0.4.0.bazel"
+            }
+          },
+          "cui__gix-ignore-0.8.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b048f443a1f6b02da4205c34d2e287e3fd45d75e8e2f06cfb216630ea9bff5e3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-ignore/0.8.0/download"
+              ],
+              "strip_prefix": "gix-ignore-0.8.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-ignore-0.8.0.bazel"
+            }
+          },
+          "cui__gix-index-0.25.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f54d63a9d13c13088f41f5a3accbec284e492ac8f4f707fcc307c139622e17b7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-index/0.25.0/download"
+              ],
+              "strip_prefix": "gix-index-0.25.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-index-0.25.0.bazel"
+            }
+          },
+          "cui__gix-lock-10.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "47fc96fa8b6b6d33555021907c81eb3b27635daecf6e630630bdad44f8feaa95",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-lock/10.0.0/download"
+              ],
+              "strip_prefix": "gix-lock-10.0.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-lock-10.0.0.bazel"
+            }
+          },
+          "cui__gix-macros-0.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9d8acb5ee668d55f0f2d19a320a3f9ef67a6999ad483e11135abcc2464ed18b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-macros/0.1.0/download"
+              ],
+              "strip_prefix": "gix-macros-0.1.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-macros-0.1.0.bazel"
+            }
+          },
+          "cui__gix-negotiate-0.8.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6f1697bf9911c6d1b8d709b9e6ef718cb5ea5821a1b7991520125a8134448004",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-negotiate/0.8.0/download"
+              ],
+              "strip_prefix": "gix-negotiate-0.8.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-negotiate-0.8.0.bazel"
+            }
+          },
+          "cui__gix-object-0.37.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1e7e19616c67967374137bae83e950e9b518a9ea8a605069bd6716ada357fd6f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-object/0.37.0/download"
+              ],
+              "strip_prefix": "gix-object-0.37.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-object-0.37.0.bazel"
+            }
+          },
+          "cui__gix-odb-0.53.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8d6a392c6ba3a2f133cdc63120e9bc7aec81eef763db372c817de31febfe64bf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-odb/0.53.0/download"
+              ],
+              "strip_prefix": "gix-odb-0.53.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-odb-0.53.0.bazel"
+            }
+          },
+          "cui__gix-pack-0.43.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7536203a45b31e1bc5694bbf90ba8da1b736c77040dd6a520db369f371eb1ab3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-pack/0.43.0/download"
+              ],
+              "strip_prefix": "gix-pack-0.43.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-pack-0.43.0.bazel"
+            }
+          },
+          "cui__gix-packetline-0.16.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8a8384b1e964151aff0d5632dd9b191059d07dff358b96bd940f1b452600d7ab",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-packetline/0.16.7/download"
+              ],
+              "strip_prefix": "gix-packetline-0.16.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-packetline-0.16.7.bazel"
+            }
+          },
+          "cui__gix-packetline-blocking-0.16.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7d8395f7501c84d6a1fe902035fdfd8cd86d89e2dd6be0200ec1a72fd3c92d39",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-packetline-blocking/0.16.6/download"
+              ],
+              "strip_prefix": "gix-packetline-blocking-0.16.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-packetline-blocking-0.16.6.bazel"
+            }
+          },
+          "cui__gix-path-0.10.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6a1d370115171e3ae03c5c6d4f7d096f2981a40ddccb98dfd704c773530ba73b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-path/0.10.0/download"
+              ],
+              "strip_prefix": "gix-path-0.10.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-path-0.10.0.bazel"
+            }
+          },
+          "cui__gix-pathspec-0.3.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c3e26c9b47c51be73f98d38c84494bd5fb99334c5d6fda14ef5d036d50a9e5fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-pathspec/0.3.0/download"
+              ],
+              "strip_prefix": "gix-pathspec-0.3.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-pathspec-0.3.0.bazel"
+            }
+          },
+          "cui__gix-prompt-0.7.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5c9a913769516f5e9d937afac206fb76428e3d7238e538845842887fda584678",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-prompt/0.7.0/download"
+              ],
+              "strip_prefix": "gix-prompt-0.7.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-prompt-0.7.0.bazel"
+            }
+          },
+          "cui__gix-protocol-0.40.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cc7b700dc20cc9be8a5130a1fd7e10c34117ffa7068431c8c24d963f0a2e0c9b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-protocol/0.40.0/download"
+              ],
+              "strip_prefix": "gix-protocol-0.40.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-protocol-0.40.0.bazel"
+            }
+          },
+          "cui__gix-quote-0.4.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "475c86a97dd0127ba4465fbb239abac9ea10e68301470c9791a6dd5351cdc905",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-quote/0.4.7/download"
+              ],
+              "strip_prefix": "gix-quote-0.4.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-quote-0.4.7.bazel"
+            }
+          },
+          "cui__gix-ref-0.37.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "22e6b749660b613641769edc1954132eb8071a13c32224891686091bef078de4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-ref/0.37.0/download"
+              ],
+              "strip_prefix": "gix-ref-0.37.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-ref-0.37.0.bazel"
+            }
+          },
+          "cui__gix-refspec-0.18.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0895cb7b1e70f3c3bd4550c329e9f5caf2975f97fcd4238e05754e72208ef61e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-refspec/0.18.0/download"
+              ],
+              "strip_prefix": "gix-refspec-0.18.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-refspec-0.18.0.bazel"
+            }
+          },
+          "cui__gix-revision-0.22.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c8c4b15cf2ab7a35f5bcb3ef146187c8d36df0177e171ca061913cbaaa890e89",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-revision/0.22.0/download"
+              ],
+              "strip_prefix": "gix-revision-0.22.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-revision-0.22.0.bazel"
+            }
+          },
+          "cui__gix-revwalk-0.8.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e9870c6b1032f2084567710c3b2106ac603377f8d25766b8a6b7c33e6e3ca279",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-revwalk/0.8.0/download"
+              ],
+              "strip_prefix": "gix-revwalk-0.8.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-revwalk-0.8.0.bazel"
+            }
+          },
+          "cui__gix-sec-0.10.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "92b9542ac025a8c02ed5d17b3fc031a111a384e859d0be3532ec4d58c40a0f28",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-sec/0.10.0/download"
+              ],
+              "strip_prefix": "gix-sec-0.10.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-sec-0.10.0.bazel"
+            }
+          },
+          "cui__gix-submodule-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "dd0150e82e9282d3f2ab2dd57a22f9f6c3447b9d9856e5321ac92d38e3e0e2b7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-submodule/0.4.0/download"
+              ],
+              "strip_prefix": "gix-submodule-0.4.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-submodule-0.4.0.bazel"
+            }
+          },
+          "cui__gix-tempfile-10.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5ae0978f3e11dc57290ee75ac2477c815bca1ce2fa7ed5dc5f16db067410ac4d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-tempfile/10.0.0/download"
+              ],
+              "strip_prefix": "gix-tempfile-10.0.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-tempfile-10.0.0.bazel"
+            }
+          },
+          "cui__gix-trace-0.1.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "96b6d623a1152c3facb79067d6e2ecdae48130030cf27d6eb21109f13bd7b836",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-trace/0.1.3/download"
+              ],
+              "strip_prefix": "gix-trace-0.1.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-trace-0.1.3.bazel"
+            }
+          },
+          "cui__gix-transport-0.37.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b9ec726e6a245e68ace59a34126a1d679de60360676612985e70b0d3b102fb4e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-transport/0.37.0/download"
+              ],
+              "strip_prefix": "gix-transport-0.37.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-transport-0.37.0.bazel"
+            }
+          },
+          "cui__gix-traverse-0.33.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "22ef04ab3643acba289b5cedd25d6f53c0430770b1d689d1d654511e6fb81ba0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-traverse/0.33.0/download"
+              ],
+              "strip_prefix": "gix-traverse-0.33.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-traverse-0.33.0.bazel"
+            }
+          },
+          "cui__gix-url-0.24.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6125ecf46e8c68bf7202da6cad239831daebf0247ffbab30210d72f3856e420f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-url/0.24.0/download"
+              ],
+              "strip_prefix": "gix-url-0.24.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-url-0.24.0.bazel"
+            }
+          },
+          "cui__gix-utils-0.1.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b85d89dc728613e26e0ed952a19583744e7f5240fcd4aa30d6c824ffd8b52f0f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-utils/0.1.5/download"
+              ],
+              "strip_prefix": "gix-utils-0.1.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-utils-0.1.5.bazel"
+            }
+          },
+          "cui__gix-validate-0.8.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e05cab2b03a45b866156e052aa38619f4ece4adcb2f79978bfc249bc3b21b8c5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-validate/0.8.0/download"
+              ],
+              "strip_prefix": "gix-validate-0.8.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-validate-0.8.0.bazel"
+            }
+          },
+          "cui__gix-worktree-0.26.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9f5e32972801bd82d56609e6fc84efc358fa1f11f25c5e83b7807ee2280f14fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-worktree/0.26.0/download"
+              ],
+              "strip_prefix": "gix-worktree-0.26.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-worktree-0.26.0.bazel"
+            }
+          },
+          "cui__globset-0.4.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1391ab1f92ffcc08911957149833e682aa3fe252b9f45f966d2ef972274c97df",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/globset/0.4.11/download"
+              ],
+              "strip_prefix": "globset-0.4.11",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.globset-0.4.11.bazel"
+            }
+          },
+          "cui__globwalk-0.8.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/globwalk/0.8.1/download"
+              ],
+              "strip_prefix": "globwalk-0.8.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.globwalk-0.8.1.bazel"
+            }
+          },
+          "cui__hashbrown-0.14.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.14.3/download"
+              ],
+              "strip_prefix": "hashbrown-0.14.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.hashbrown-0.14.3.bazel"
+            }
+          },
+          "cui__heck-0.4.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.4.1/download"
+              ],
+              "strip_prefix": "heck-0.4.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.heck-0.4.1.bazel"
+            }
+          },
+          "cui__hermit-abi-0.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.3.2/download"
+              ],
+              "strip_prefix": "hermit-abi-0.3.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
+            }
+          },
+          "cui__hex-0.4.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hex/0.4.3/download"
+              ],
+              "strip_prefix": "hex-0.4.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.hex-0.4.3.bazel"
+            }
+          },
+          "cui__home-0.5.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/home/0.5.5/download"
+              ],
+              "strip_prefix": "home-0.5.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.home-0.5.5.bazel"
+            }
+          },
+          "cui__humansize-2.1.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/humansize/2.1.3/download"
+              ],
+              "strip_prefix": "humansize-2.1.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.humansize-2.1.3.bazel"
+            }
+          },
+          "cui__iana-time-zone-0.1.57": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/iana-time-zone/0.1.57/download"
+              ],
+              "strip_prefix": "iana-time-zone-0.1.57",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.iana-time-zone-0.1.57.bazel"
+            }
+          },
+          "cui__iana-time-zone-haiku-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/iana-time-zone-haiku/0.1.2/download"
+              ],
+              "strip_prefix": "iana-time-zone-haiku-0.1.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.iana-time-zone-haiku-0.1.2.bazel"
+            }
+          },
+          "cui__idna-0.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/idna/0.5.0/download"
+              ],
+              "strip_prefix": "idna-0.5.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.idna-0.5.0.bazel"
+            }
+          },
+          "cui__ignore-0.4.18": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ignore/0.4.18/download"
+              ],
+              "strip_prefix": "ignore-0.4.18",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ignore-0.4.18.bazel"
+            }
+          },
+          "cui__indexmap-2.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/2.1.0/download"
+              ],
+              "strip_prefix": "indexmap-2.1.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.indexmap-2.1.0.bazel"
+            }
+          },
+          "cui__indoc-2.0.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indoc/2.0.4/download"
+              ],
+              "strip_prefix": "indoc-2.0.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.indoc-2.0.4.bazel"
+            }
+          },
+          "cui__io-lifetimes-1.0.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
+              ],
+              "strip_prefix": "io-lifetimes-1.0.11",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
+            }
+          },
+          "cui__is-terminal-0.4.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/is-terminal/0.4.7/download"
+              ],
+              "strip_prefix": "is-terminal-0.4.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.is-terminal-0.4.7.bazel"
+            }
+          },
+          "cui__itertools-0.12.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.12.0/download"
+              ],
+              "strip_prefix": "itertools-0.12.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.itertools-0.12.0.bazel"
+            }
+          },
+          "cui__itoa-1.0.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itoa/1.0.8/download"
+              ],
+              "strip_prefix": "itoa-1.0.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
+            }
+          },
+          "cui__js-sys-0.3.64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/js-sys/0.3.64/download"
+              ],
+              "strip_prefix": "js-sys-0.3.64",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.js-sys-0.3.64.bazel"
+            }
+          },
+          "cui__jwalk-0.8.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/jwalk/0.8.1/download"
+              ],
+              "strip_prefix": "jwalk-0.8.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.jwalk-0.8.1.bazel"
+            }
+          },
+          "cui__lazy_static-1.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lazy_static/1.4.0/download"
+              ],
+              "strip_prefix": "lazy_static-1.4.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
+            }
+          },
+          "cui__libc-0.2.149": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.149/download"
+              ],
+              "strip_prefix": "libc-0.2.149",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.libc-0.2.149.bazel"
+            }
+          },
+          "cui__libm-0.2.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libm/0.2.7/download"
+              ],
+              "strip_prefix": "libm-0.2.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.libm-0.2.7.bazel"
+            }
+          },
+          "cui__linux-raw-sys-0.3.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.3.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
+            }
+          },
+          "cui__linux-raw-sys-0.4.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.4.10/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.4.10",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.linux-raw-sys-0.4.10.bazel"
+            }
+          },
+          "cui__lock_api-0.4.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lock_api/0.4.11/download"
+              ],
+              "strip_prefix": "lock_api-0.4.11",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.lock_api-0.4.11.bazel"
+            }
+          },
+          "cui__log-0.4.19": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.19/download"
+              ],
+              "strip_prefix": "log-0.4.19",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.log-0.4.19.bazel"
+            }
+          },
+          "cui__maplit-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/maplit/1.0.2/download"
+              ],
+              "strip_prefix": "maplit-1.0.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.maplit-1.0.2.bazel"
+            }
+          },
+          "cui__maybe-async-0.2.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/maybe-async/0.2.7/download"
+              ],
+              "strip_prefix": "maybe-async-0.2.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.maybe-async-0.2.7.bazel"
+            }
+          },
+          "cui__memchr-2.6.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.6.4/download"
+              ],
+              "strip_prefix": "memchr-2.6.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.memchr-2.6.4.bazel"
+            }
+          },
+          "cui__memmap2-0.7.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memmap2/0.7.1/download"
+              ],
+              "strip_prefix": "memmap2-0.7.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.memmap2-0.7.1.bazel"
+            }
+          },
+          "cui__memoffset-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memoffset/0.9.0/download"
+              ],
+              "strip_prefix": "memoffset-0.9.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.memoffset-0.9.0.bazel"
+            }
+          },
+          "cui__miniz_oxide-0.7.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/miniz_oxide/0.7.1/download"
+              ],
+              "strip_prefix": "miniz_oxide-0.7.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.miniz_oxide-0.7.1.bazel"
+            }
+          },
+          "cui__normpath-1.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/normpath/1.1.1/download"
+              ],
+              "strip_prefix": "normpath-1.1.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.normpath-1.1.1.bazel"
+            }
+          },
+          "cui__nu-ansi-term-0.46.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/nu-ansi-term/0.46.0/download"
+              ],
+              "strip_prefix": "nu-ansi-term-0.46.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.nu-ansi-term-0.46.0.bazel"
+            }
+          },
+          "cui__num-0.1.42": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num/0.1.42/download"
+              ],
+              "strip_prefix": "num-0.1.42",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-0.1.42.bazel"
+            }
+          },
+          "cui__num-bigint-0.1.44": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-bigint/0.1.44/download"
+              ],
+              "strip_prefix": "num-bigint-0.1.44",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-bigint-0.1.44.bazel"
+            }
+          },
+          "cui__num-complex-0.1.43": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-complex/0.1.43/download"
+              ],
+              "strip_prefix": "num-complex-0.1.43",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-complex-0.1.43.bazel"
+            }
+          },
+          "cui__num-conv-0.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-conv/0.1.0/download"
+              ],
+              "strip_prefix": "num-conv-0.1.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-conv-0.1.0.bazel"
+            }
+          },
+          "cui__num-integer-0.1.45": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-integer/0.1.45/download"
+              ],
+              "strip_prefix": "num-integer-0.1.45",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-integer-0.1.45.bazel"
+            }
+          },
+          "cui__num-iter-0.1.43": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-iter/0.1.43/download"
+              ],
+              "strip_prefix": "num-iter-0.1.43",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-iter-0.1.43.bazel"
+            }
+          },
+          "cui__num-rational-0.1.42": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-rational/0.1.42/download"
+              ],
+              "strip_prefix": "num-rational-0.1.42",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-rational-0.1.42.bazel"
+            }
+          },
+          "cui__num-traits-0.2.15": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-traits/0.2.15/download"
+              ],
+              "strip_prefix": "num-traits-0.2.15",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-traits-0.2.15.bazel"
+            }
+          },
+          "cui__num_threads-0.1.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num_threads/0.1.6/download"
+              ],
+              "strip_prefix": "num_threads-0.1.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num_threads-0.1.6.bazel"
+            }
+          },
+          "cui__once_cell-1.19.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.19.0/download"
+              ],
+              "strip_prefix": "once_cell-1.19.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.once_cell-1.19.0.bazel"
+            }
+          },
+          "cui__overload-0.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/overload/0.1.1/download"
+              ],
+              "strip_prefix": "overload-0.1.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.overload-0.1.1.bazel"
+            }
+          },
+          "cui__parking_lot-0.12.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot/0.12.1/download"
+              ],
+              "strip_prefix": "parking_lot-0.12.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.parking_lot-0.12.1.bazel"
+            }
+          },
+          "cui__parking_lot_core-0.9.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot_core/0.9.9/download"
+              ],
+              "strip_prefix": "parking_lot_core-0.9.9",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.parking_lot_core-0.9.9.bazel"
+            }
+          },
+          "cui__parse-zoneinfo-0.3.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parse-zoneinfo/0.3.0/download"
+              ],
+              "strip_prefix": "parse-zoneinfo-0.3.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.parse-zoneinfo-0.3.0.bazel"
+            }
+          },
+          "cui__pathdiff-0.2.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pathdiff/0.2.1/download"
+              ],
+              "strip_prefix": "pathdiff-0.2.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pathdiff-0.2.1.bazel"
+            }
+          },
+          "cui__percent-encoding-2.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/percent-encoding/2.3.1/download"
+              ],
+              "strip_prefix": "percent-encoding-2.3.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.percent-encoding-2.3.1.bazel"
+            }
+          },
+          "cui__pest-2.7.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pest/2.7.0/download"
+              ],
+              "strip_prefix": "pest-2.7.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pest-2.7.0.bazel"
+            }
+          },
+          "cui__pest_derive-2.7.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pest_derive/2.7.0/download"
+              ],
+              "strip_prefix": "pest_derive-2.7.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pest_derive-2.7.0.bazel"
+            }
+          },
+          "cui__pest_generator-2.7.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pest_generator/2.7.0/download"
+              ],
+              "strip_prefix": "pest_generator-2.7.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pest_generator-2.7.0.bazel"
+            }
+          },
+          "cui__pest_meta-2.7.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pest_meta/2.7.0/download"
+              ],
+              "strip_prefix": "pest_meta-2.7.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pest_meta-2.7.0.bazel"
+            }
+          },
+          "cui__phf-0.11.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/phf/0.11.2/download"
+              ],
+              "strip_prefix": "phf-0.11.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.phf-0.11.2.bazel"
+            }
+          },
+          "cui__phf_codegen-0.11.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/phf_codegen/0.11.2/download"
+              ],
+              "strip_prefix": "phf_codegen-0.11.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.phf_codegen-0.11.2.bazel"
+            }
+          },
+          "cui__phf_generator-0.11.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/phf_generator/0.11.2/download"
+              ],
+              "strip_prefix": "phf_generator-0.11.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.phf_generator-0.11.2.bazel"
+            }
+          },
+          "cui__phf_shared-0.11.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/phf_shared/0.11.2/download"
+              ],
+              "strip_prefix": "phf_shared-0.11.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.phf_shared-0.11.2.bazel"
+            }
+          },
+          "cui__pin-project-lite-0.2.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project-lite/0.2.13/download"
+              ],
+              "strip_prefix": "pin-project-lite-0.2.13",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pin-project-lite-0.2.13.bazel"
+            }
+          },
+          "cui__powerfmt-0.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/powerfmt/0.2.0/download"
+              ],
+              "strip_prefix": "powerfmt-0.2.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.powerfmt-0.2.0.bazel"
+            }
+          },
+          "cui__ppv-lite86-0.2.17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ppv-lite86/0.2.17/download"
+              ],
+              "strip_prefix": "ppv-lite86-0.2.17",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ppv-lite86-0.2.17.bazel"
+            }
+          },
+          "cui__proc-macro2-1.0.64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.64/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.64",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.proc-macro2-1.0.64.bazel"
+            }
+          },
+          "cui__prodash-26.2.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "794b5bf8e2d19b53dcdcec3e4bba628e20f5b6062503ba89281fa7037dd7bbcf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prodash/26.2.2/download"
+              ],
+              "strip_prefix": "prodash-26.2.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.prodash-26.2.2.bazel"
+            }
+          },
+          "cui__quote-1.0.29": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.29/download"
+              ],
+              "strip_prefix": "quote-1.0.29",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.quote-1.0.29.bazel"
+            }
+          },
+          "cui__rand-0.4.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand/0.4.6/download"
+              ],
+              "strip_prefix": "rand-0.4.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand-0.4.6.bazel"
+            }
+          },
+          "cui__rand-0.8.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand/0.8.5/download"
+              ],
+              "strip_prefix": "rand-0.8.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand-0.8.5.bazel"
+            }
+          },
+          "cui__rand_chacha-0.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
+              ],
+              "strip_prefix": "rand_chacha-0.3.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
+            }
+          },
+          "cui__rand_core-0.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_core/0.3.1/download"
+              ],
+              "strip_prefix": "rand_core-0.3.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand_core-0.3.1.bazel"
+            }
+          },
+          "cui__rand_core-0.4.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_core/0.4.2/download"
+              ],
+              "strip_prefix": "rand_core-0.4.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand_core-0.4.2.bazel"
+            }
+          },
+          "cui__rand_core-0.6.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_core/0.6.4/download"
+              ],
+              "strip_prefix": "rand_core-0.6.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
+            }
+          },
+          "cui__rayon-1.8.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rayon/1.8.0/download"
+              ],
+              "strip_prefix": "rayon-1.8.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rayon-1.8.0.bazel"
+            }
+          },
+          "cui__rayon-core-1.12.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rayon-core/1.12.0/download"
+              ],
+              "strip_prefix": "rayon-core-1.12.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rayon-core-1.12.0.bazel"
+            }
+          },
+          "cui__rdrand-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rdrand/0.4.0/download"
+              ],
+              "strip_prefix": "rdrand-0.4.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rdrand-0.4.0.bazel"
+            }
+          },
+          "cui__redox_syscall-0.3.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.3.5/download"
+              ],
+              "strip_prefix": "redox_syscall-0.3.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.redox_syscall-0.3.5.bazel"
+            }
+          },
+          "cui__redox_syscall-0.4.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.4.1/download"
+              ],
+              "strip_prefix": "redox_syscall-0.4.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.redox_syscall-0.4.1.bazel"
+            }
+          },
+          "cui__regex-1.10.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.10.2/download"
+              ],
+              "strip_prefix": "regex-1.10.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-1.10.2.bazel"
+            }
+          },
+          "cui__regex-automata-0.3.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.3.3/download"
+              ],
+              "strip_prefix": "regex-automata-0.3.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
+            }
+          },
+          "cui__regex-automata-0.4.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.4.3/download"
+              ],
+              "strip_prefix": "regex-automata-0.4.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-automata-0.4.3.bazel"
+            }
+          },
+          "cui__regex-syntax-0.8.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.8.2/download"
+              ],
+              "strip_prefix": "regex-syntax-0.8.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-syntax-0.8.2.bazel"
+            }
+          },
+          "cui__rustc-hash-1.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-hash/1.1.0/download"
+              ],
+              "strip_prefix": "rustc-hash-1.1.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rustc-hash-1.1.0.bazel"
+            }
+          },
+          "cui__rustc-serialize-0.3.25": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-serialize/0.3.25/download"
+              ],
+              "strip_prefix": "rustc-serialize-0.3.25",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rustc-serialize-0.3.25.bazel"
+            }
+          },
+          "cui__rustix-0.37.23": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.37.23/download"
+              ],
+              "strip_prefix": "rustix-0.37.23",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
+            }
+          },
+          "cui__rustix-0.38.21": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.38.21/download"
+              ],
+              "strip_prefix": "rustix-0.38.21",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rustix-0.38.21.bazel"
+            }
+          },
+          "cui__ryu-1.0.14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ryu/1.0.14/download"
+              ],
+              "strip_prefix": "ryu-1.0.14",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
+            }
+          },
+          "cui__same-file-1.0.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/same-file/1.0.6/download"
+              ],
+              "strip_prefix": "same-file-1.0.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.same-file-1.0.6.bazel"
+            }
+          },
+          "cui__scopeguard-1.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scopeguard/1.2.0/download"
+              ],
+              "strip_prefix": "scopeguard-1.2.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.scopeguard-1.2.0.bazel"
+            }
+          },
+          "cui__semver-1.0.20": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/semver/1.0.20/download"
+              ],
+              "strip_prefix": "semver-1.0.20",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.semver-1.0.20.bazel"
+            }
+          },
+          "cui__serde-1.0.190": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde/1.0.190/download"
+              ],
+              "strip_prefix": "serde-1.0.190",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde-1.0.190.bazel"
+            }
+          },
+          "cui__serde_derive-1.0.190": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_derive/1.0.190/download"
+              ],
+              "strip_prefix": "serde_derive-1.0.190",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_derive-1.0.190.bazel"
+            }
+          },
+          "cui__serde_json-1.0.108": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_json/1.0.108/download"
+              ],
+              "strip_prefix": "serde_json-1.0.108",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_json-1.0.108.bazel"
+            }
+          },
+          "cui__serde_spanned-0.6.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_spanned/0.6.5/download"
+              ],
+              "strip_prefix": "serde_spanned-0.6.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_spanned-0.6.5.bazel"
+            }
+          },
+          "cui__serde_starlark-0.1.14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "29675b116dd4c7ab4012e00e71f6dee9ed8c731108468b4434779c6b9eec7957",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_starlark/0.1.14/download"
+              ],
+              "strip_prefix": "serde_starlark-0.1.14",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_starlark-0.1.14.bazel"
+            }
+          },
+          "cui__sha1_smol-1.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sha1_smol/1.0.0/download"
+              ],
+              "strip_prefix": "sha1_smol-1.0.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.sha1_smol-1.0.0.bazel"
+            }
+          },
+          "cui__sha2-0.10.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sha2/0.10.8/download"
+              ],
+              "strip_prefix": "sha2-0.10.8",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.sha2-0.10.8.bazel"
+            }
+          },
+          "cui__sharded-slab-0.1.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sharded-slab/0.1.7/download"
+              ],
+              "strip_prefix": "sharded-slab-0.1.7",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.sharded-slab-0.1.7.bazel"
+            }
+          },
+          "cui__siphasher-0.3.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/siphasher/0.3.10/download"
+              ],
+              "strip_prefix": "siphasher-0.3.10",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.siphasher-0.3.10.bazel"
+            }
+          },
+          "cui__slug-0.1.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/slug/0.1.4/download"
+              ],
+              "strip_prefix": "slug-0.1.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.slug-0.1.4.bazel"
+            }
+          },
+          "cui__smallvec-1.11.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smallvec/1.11.0/download"
+              ],
+              "strip_prefix": "smallvec-1.11.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.smallvec-1.11.0.bazel"
+            }
+          },
+          "cui__smawk-0.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smawk/0.3.1/download"
+              ],
+              "strip_prefix": "smawk-0.3.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.smawk-0.3.1.bazel"
+            }
+          },
+          "cui__smol_str-0.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smol_str/0.2.0/download"
+              ],
+              "strip_prefix": "smol_str-0.2.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.smol_str-0.2.0.bazel"
+            }
+          },
+          "cui__spdx-0.10.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "62bde1398b09b9f93fc2fc9b9da86e362693e999d3a54a8ac47a99a5a73f638b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/spdx/0.10.3/download"
+              ],
+              "strip_prefix": "spdx-0.10.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.spdx-0.10.3.bazel"
+            }
+          },
+          "cui__spectral-0.6.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/spectral/0.6.0/download"
+              ],
+              "strip_prefix": "spectral-0.6.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.spectral-0.6.0.bazel"
+            }
+          },
+          "cui__strsim-0.10.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.10.0/download"
+              ],
+              "strip_prefix": "strsim-0.10.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
+            }
+          },
+          "cui__syn-1.0.109": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/1.0.109/download"
+              ],
+              "strip_prefix": "syn-1.0.109",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.syn-1.0.109.bazel"
+            }
+          },
+          "cui__syn-2.0.32": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.32/download"
+              ],
+              "strip_prefix": "syn-2.0.32",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.syn-2.0.32.bazel"
+            }
+          },
+          "cui__tempfile-3.8.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tempfile/3.8.1/download"
+              ],
+              "strip_prefix": "tempfile-3.8.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tempfile-3.8.1.bazel"
+            }
+          },
+          "cui__tera-1.19.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "970dff17c11e884a4a09bc76e3a17ef71e01bb13447a11e85226e254fe6d10b8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tera/1.19.1/download"
+              ],
+              "strip_prefix": "tera-1.19.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tera-1.19.1.bazel"
+            }
+          },
+          "cui__textwrap-0.16.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/textwrap/0.16.0/download"
+              ],
+              "strip_prefix": "textwrap-0.16.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.textwrap-0.16.0.bazel"
+            }
+          },
+          "cui__thiserror-1.0.50": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/thiserror/1.0.50/download"
+              ],
+              "strip_prefix": "thiserror-1.0.50",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.thiserror-1.0.50.bazel"
+            }
+          },
+          "cui__thiserror-impl-1.0.50": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/thiserror-impl/1.0.50/download"
+              ],
+              "strip_prefix": "thiserror-impl-1.0.50",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.thiserror-impl-1.0.50.bazel"
+            }
+          },
+          "cui__thread_local-1.1.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/thread_local/1.1.4/download"
+              ],
+              "strip_prefix": "thread_local-1.1.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.thread_local-1.1.4.bazel"
+            }
+          },
+          "cui__time-0.3.36": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/time/0.3.36/download"
+              ],
+              "strip_prefix": "time-0.3.36",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.time-0.3.36.bazel"
+            }
+          },
+          "cui__time-core-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/time-core/0.1.2/download"
+              ],
+              "strip_prefix": "time-core-0.1.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.time-core-0.1.2.bazel"
+            }
+          },
+          "cui__time-macros-0.2.18": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/time-macros/0.2.18/download"
+              ],
+              "strip_prefix": "time-macros-0.2.18",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.time-macros-0.2.18.bazel"
+            }
+          },
+          "cui__tinyvec-1.6.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tinyvec/1.6.0/download"
+              ],
+              "strip_prefix": "tinyvec-1.6.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tinyvec-1.6.0.bazel"
+            }
+          },
+          "cui__tinyvec_macros-0.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tinyvec_macros/0.1.1/download"
+              ],
+              "strip_prefix": "tinyvec_macros-0.1.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tinyvec_macros-0.1.1.bazel"
+            }
+          },
+          "cui__toml-0.7.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml/0.7.6/download"
+              ],
+              "strip_prefix": "toml-0.7.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml-0.7.6.bazel"
+            }
+          },
+          "cui__toml-0.8.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml/0.8.10/download"
+              ],
+              "strip_prefix": "toml-0.8.10",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml-0.8.10.bazel"
+            }
+          },
+          "cui__toml_datetime-0.6.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml_datetime/0.6.5/download"
+              ],
+              "strip_prefix": "toml_datetime-0.6.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml_datetime-0.6.5.bazel"
+            }
+          },
+          "cui__toml_edit-0.19.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5f8751d9c1b03c6500c387e96f81f815a4f8e72d142d2d4a9ffa6fedd51ddee7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml_edit/0.19.13/download"
+              ],
+              "strip_prefix": "toml_edit-0.19.13",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml_edit-0.19.13.bazel"
+            }
+          },
+          "cui__toml_edit-0.22.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml_edit/0.22.4/download"
+              ],
+              "strip_prefix": "toml_edit-0.22.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml_edit-0.22.4.bazel"
+            }
+          },
+          "cui__tracing-0.1.40": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing/0.1.40/download"
+              ],
+              "strip_prefix": "tracing-0.1.40",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-0.1.40.bazel"
+            }
+          },
+          "cui__tracing-attributes-0.1.27": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-attributes/0.1.27/download"
+              ],
+              "strip_prefix": "tracing-attributes-0.1.27",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-attributes-0.1.27.bazel"
+            }
+          },
+          "cui__tracing-core-0.1.32": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-core/0.1.32/download"
+              ],
+              "strip_prefix": "tracing-core-0.1.32",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-core-0.1.32.bazel"
+            }
+          },
+          "cui__tracing-log-0.1.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-log/0.1.4/download"
+              ],
+              "strip_prefix": "tracing-log-0.1.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-log-0.1.4.bazel"
+            }
+          },
+          "cui__tracing-subscriber-0.3.17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-subscriber/0.3.17/download"
+              ],
+              "strip_prefix": "tracing-subscriber-0.3.17",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-subscriber-0.3.17.bazel"
+            }
+          },
+          "cui__typenum-1.16.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/typenum/1.16.0/download"
+              ],
+              "strip_prefix": "typenum-1.16.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.typenum-1.16.0.bazel"
+            }
+          },
+          "cui__ucd-trie-0.1.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ucd-trie/0.1.6/download"
+              ],
+              "strip_prefix": "ucd-trie-0.1.6",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ucd-trie-0.1.6.bazel"
+            }
+          },
+          "cui__uluru-3.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/uluru/3.0.0/download"
+              ],
+              "strip_prefix": "uluru-3.0.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.uluru-3.0.0.bazel"
+            }
+          },
+          "cui__unic-char-property-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-char-property/0.9.0/download"
+              ],
+              "strip_prefix": "unic-char-property-0.9.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-char-property-0.9.0.bazel"
+            }
+          },
+          "cui__unic-char-range-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-char-range/0.9.0/download"
+              ],
+              "strip_prefix": "unic-char-range-0.9.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-char-range-0.9.0.bazel"
+            }
+          },
+          "cui__unic-common-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-common/0.9.0/download"
+              ],
+              "strip_prefix": "unic-common-0.9.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-common-0.9.0.bazel"
+            }
+          },
+          "cui__unic-segment-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-segment/0.9.0/download"
+              ],
+              "strip_prefix": "unic-segment-0.9.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-segment-0.9.0.bazel"
+            }
+          },
+          "cui__unic-ucd-segment-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-ucd-segment/0.9.0/download"
+              ],
+              "strip_prefix": "unic-ucd-segment-0.9.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-ucd-segment-0.9.0.bazel"
+            }
+          },
+          "cui__unic-ucd-version-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-ucd-version/0.9.0/download"
+              ],
+              "strip_prefix": "unic-ucd-version-0.9.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-ucd-version-0.9.0.bazel"
+            }
+          },
+          "cui__unicode-bidi-0.3.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-bidi/0.3.13/download"
+              ],
+              "strip_prefix": "unicode-bidi-0.3.13",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-bidi-0.3.13.bazel"
+            }
+          },
+          "cui__unicode-bom-2.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "98e90c70c9f0d4d1ee6d0a7d04aa06cb9bbd53d8cfbdd62a0269a7c2eb640552",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-bom/2.0.2/download"
+              ],
+              "strip_prefix": "unicode-bom-2.0.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-bom-2.0.2.bazel"
+            }
+          },
+          "cui__unicode-ident-1.0.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.10/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.10",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
+            }
+          },
+          "cui__unicode-linebreak-0.1.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-linebreak/0.1.5/download"
+              ],
+              "strip_prefix": "unicode-linebreak-0.1.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-linebreak-0.1.5.bazel"
+            }
+          },
+          "cui__unicode-normalization-0.1.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-normalization/0.1.22/download"
+              ],
+              "strip_prefix": "unicode-normalization-0.1.22",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-normalization-0.1.22.bazel"
+            }
+          },
+          "cui__unicode-width-0.1.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-width/0.1.10/download"
+              ],
+              "strip_prefix": "unicode-width-0.1.10",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-width-0.1.10.bazel"
+            }
+          },
+          "cui__url-2.5.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/url/2.5.2/download"
+              ],
+              "strip_prefix": "url-2.5.2",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.url-2.5.2.bazel"
+            }
+          },
+          "cui__utf8parse-0.2.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/utf8parse/0.2.1/download"
+              ],
+              "strip_prefix": "utf8parse-0.2.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.utf8parse-0.2.1.bazel"
+            }
+          },
+          "cui__valuable-0.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/valuable/0.1.0/download"
+              ],
+              "strip_prefix": "valuable-0.1.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.valuable-0.1.0.bazel"
+            }
+          },
+          "cui__version_check-0.9.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/version_check/0.9.4/download"
+              ],
+              "strip_prefix": "version_check-0.9.4",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.version_check-0.9.4.bazel"
+            }
+          },
+          "cui__walkdir-2.3.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/walkdir/2.3.3/download"
+              ],
+              "strip_prefix": "walkdir-2.3.3",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.walkdir-2.3.3.bazel"
+            }
+          },
+          "cui__wasi-0.11.0-wasi-snapshot-preview1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
+              ],
+              "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
+            }
+          },
+          "cui__wasm-bindgen-0.2.87": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen/0.2.87/download"
+              ],
+              "strip_prefix": "wasm-bindgen-0.2.87",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-0.2.87.bazel"
+            }
+          },
+          "cui__wasm-bindgen-backend-0.2.87": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-backend/0.2.87/download"
+              ],
+              "strip_prefix": "wasm-bindgen-backend-0.2.87",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-backend-0.2.87.bazel"
+            }
+          },
+          "cui__wasm-bindgen-macro-0.2.87": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-macro/0.2.87/download"
+              ],
+              "strip_prefix": "wasm-bindgen-macro-0.2.87",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-macro-0.2.87.bazel"
+            }
+          },
+          "cui__wasm-bindgen-macro-support-0.2.87": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.87/download"
+              ],
+              "strip_prefix": "wasm-bindgen-macro-support-0.2.87",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-macro-support-0.2.87.bazel"
+            }
+          },
+          "cui__wasm-bindgen-shared-0.2.87": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-shared/0.2.87/download"
+              ],
+              "strip_prefix": "wasm-bindgen-shared-0.2.87",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-shared-0.2.87.bazel"
+            }
+          },
+          "cui__winapi-0.3.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "cui__winapi-i686-pc-windows-gnu-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "cui__winapi-util-0.1.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-util/0.1.5/download"
+              ],
+              "strip_prefix": "winapi-util-0.1.5",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
+            }
+          },
+          "cui__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "cui__windows-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows/0.48.0/download"
+              ],
+              "strip_prefix": "windows-0.48.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows-0.48.0.bazel"
+            }
+          },
+          "cui__windows-sys-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.48.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.48.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
+            }
+          },
+          "cui__windows-targets-0.48.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.48.1/download"
+              ],
+              "strip_prefix": "windows-targets-0.48.1",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
+            }
+          },
+          "cui__windows_aarch64_gnullvm-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "cui__windows_aarch64_msvc-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.48.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
+            }
+          },
+          "cui__windows_i686_gnu-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.48.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
+            }
+          },
+          "cui__windows_i686_msvc-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.48.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
+            }
+          },
+          "cui__windows_x86_64_gnu-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.48.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
+            }
+          },
+          "cui__windows_x86_64_gnullvm-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "cui__windows_x86_64_msvc-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.48.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
+            }
+          },
+          "cui__winnow-0.5.18": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winnow/0.5.18/download"
+              ],
+              "strip_prefix": "winnow-0.5.18",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winnow-0.5.18.bazel"
+            }
+          },
+          "cargo_bazel.buildifier-darwin-amd64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-darwin-amd64"
+              ],
+              "integrity": "sha256-N1+CMQPQFiCq7CCgwpxsvKmfT9ByWuMLk2VcZwT0TXE=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-darwin-arm64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-darwin-arm64"
+              ],
+              "integrity": "sha256-Wmr8asegn1RVuguJvZnVriO0F03F3J1sDtXOjKrD+BM=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-linux-amd64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-amd64"
+              ],
+              "integrity": "sha256-VHTMUSinToBng9VAgfWBZixL6K5lAi9VfpKB7V3IgAk=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-linux-arm64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-arm64"
+              ],
+              "integrity": "sha256-C/hsS//69PCO7Xe95bIILkrlA5oR4uiwOYTBc8NKVhw=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-linux-s390x": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-s390x"
+              ],
+              "integrity": "sha256-4tef9YhdRSdPdlMfGtvHtzoSn1nnZ/d36PveYz2dTi4=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-windows-amd64.exe": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-windows-amd64.exe"
+              ],
+              "integrity": "sha256-NwzVdgda0pkwqC9d4TLxod5AhMeEqCUUvU2oDIWs9Kg=",
+              "downloaded_file_path": "buildifier.exe",
+              "executable": true
+            }
+          },
+          "rules_rust_prost": {
+            "bzlFile": "@@rules_rust~//crate_universe/private:crates_vendor.bzl",
+            "ruleClassName": "crates_vendor_remote_repository",
+            "attributes": {
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.bazel",
+              "defs_module": "@@rules_rust~//proto/prost/private/3rdparty/crates:defs.bzl"
+            }
+          },
+          "rules_rust_prost__addr2line-0.22.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/addr2line/0.22.0/download"
+              ],
+              "strip_prefix": "addr2line-0.22.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.addr2line-0.22.0.bazel"
+            }
+          },
+          "rules_rust_prost__adler-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/adler/1.0.2/download"
+              ],
+              "strip_prefix": "adler-1.0.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.adler-1.0.2.bazel"
+            }
+          },
+          "rules_rust_prost__aho-corasick-1.1.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.1.3/download"
+              ],
+              "strip_prefix": "aho-corasick-1.1.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.aho-corasick-1.1.3.bazel"
+            }
+          },
+          "rules_rust_prost__anyhow-1.0.86": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.86/download"
+              ],
+              "strip_prefix": "anyhow-1.0.86",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.anyhow-1.0.86.bazel"
+            }
+          },
+          "rules_rust_prost__async-stream-0.3.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/async-stream/0.3.5/download"
+              ],
+              "strip_prefix": "async-stream-0.3.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.async-stream-0.3.5.bazel"
+            }
+          },
+          "rules_rust_prost__async-stream-impl-0.3.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/async-stream-impl/0.3.5/download"
+              ],
+              "strip_prefix": "async-stream-impl-0.3.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.async-stream-impl-0.3.5.bazel"
+            }
+          },
+          "rules_rust_prost__async-trait-0.1.81": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/async-trait/0.1.81/download"
+              ],
+              "strip_prefix": "async-trait-0.1.81",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.async-trait-0.1.81.bazel"
+            }
+          },
+          "rules_rust_prost__atomic-waker-1.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/atomic-waker/1.1.2/download"
+              ],
+              "strip_prefix": "atomic-waker-1.1.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.atomic-waker-1.1.2.bazel"
+            }
+          },
+          "rules_rust_prost__autocfg-1.3.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.3.0/download"
+              ],
+              "strip_prefix": "autocfg-1.3.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.autocfg-1.3.0.bazel"
+            }
+          },
+          "rules_rust_prost__axum-0.7.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/axum/0.7.5/download"
+              ],
+              "strip_prefix": "axum-0.7.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.axum-0.7.5.bazel"
+            }
+          },
+          "rules_rust_prost__axum-core-0.4.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/axum-core/0.4.3/download"
+              ],
+              "strip_prefix": "axum-core-0.4.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.axum-core-0.4.3.bazel"
+            }
+          },
+          "rules_rust_prost__backtrace-0.3.73": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/backtrace/0.3.73/download"
+              ],
+              "strip_prefix": "backtrace-0.3.73",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.backtrace-0.3.73.bazel"
+            }
+          },
+          "rules_rust_prost__base64-0.22.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/base64/0.22.1/download"
+              ],
+              "strip_prefix": "base64-0.22.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.base64-0.22.1.bazel"
+            }
+          },
+          "rules_rust_prost__bitflags-2.6.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/2.6.0/download"
+              ],
+              "strip_prefix": "bitflags-2.6.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.bitflags-2.6.0.bazel"
+            }
+          },
+          "rules_rust_prost__byteorder-1.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/byteorder/1.5.0/download"
+              ],
+              "strip_prefix": "byteorder-1.5.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.byteorder-1.5.0.bazel"
+            }
+          },
+          "rules_rust_prost__bytes-1.7.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bytes/1.7.1/download"
+              ],
+              "strip_prefix": "bytes-1.7.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.bytes-1.7.1.bazel"
+            }
+          },
+          "rules_rust_prost__cc-1.1.14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "50d2eb3cd3d1bf4529e31c215ee6f93ec5a3d536d9f578f93d9d33ee19562932",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cc/1.1.14/download"
+              ],
+              "strip_prefix": "cc-1.1.14",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.cc-1.1.14.bazel"
+            }
+          },
+          "rules_rust_prost__cfg-if-1.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "rules_rust_prost__either-1.13.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.13.0/download"
+              ],
+              "strip_prefix": "either-1.13.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.either-1.13.0.bazel"
+            }
+          },
+          "rules_rust_prost__equivalent-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/equivalent/1.0.1/download"
+              ],
+              "strip_prefix": "equivalent-1.0.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
+            }
+          },
+          "rules_rust_prost__errno-0.3.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno/0.3.9/download"
+              ],
+              "strip_prefix": "errno-0.3.9",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.errno-0.3.9.bazel"
+            }
+          },
+          "rules_rust_prost__fastrand-2.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fastrand/2.1.1/download"
+              ],
+              "strip_prefix": "fastrand-2.1.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.fastrand-2.1.1.bazel"
+            }
+          },
+          "rules_rust_prost__fixedbitset-0.4.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fixedbitset/0.4.2/download"
+              ],
+              "strip_prefix": "fixedbitset-0.4.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.fixedbitset-0.4.2.bazel"
+            }
+          },
+          "rules_rust_prost__fnv-1.0.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fnv/1.0.7/download"
+              ],
+              "strip_prefix": "fnv-1.0.7",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
+            }
+          },
+          "rules_rust_prost__futures-channel-0.3.30": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-channel/0.3.30/download"
+              ],
+              "strip_prefix": "futures-channel-0.3.30",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-channel-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__futures-core-0.3.30": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-core/0.3.30/download"
+              ],
+              "strip_prefix": "futures-core-0.3.30",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-core-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__futures-sink-0.3.30": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-sink/0.3.30/download"
+              ],
+              "strip_prefix": "futures-sink-0.3.30",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-sink-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__futures-task-0.3.30": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-task/0.3.30/download"
+              ],
+              "strip_prefix": "futures-task-0.3.30",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-task-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__futures-util-0.3.30": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-util/0.3.30/download"
+              ],
+              "strip_prefix": "futures-util-0.3.30",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-util-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__getrandom-0.2.15": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/getrandom/0.2.15/download"
+              ],
+              "strip_prefix": "getrandom-0.2.15",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.getrandom-0.2.15.bazel"
+            }
+          },
+          "rules_rust_prost__gimli-0.29.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gimli/0.29.0/download"
+              ],
+              "strip_prefix": "gimli-0.29.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.gimli-0.29.0.bazel"
+            }
+          },
+          "rules_rust_prost__h2-0.4.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/h2/0.4.6/download"
+              ],
+              "strip_prefix": "h2-0.4.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.h2-0.4.6.bazel"
+            }
+          },
+          "rules_rust_prost__hashbrown-0.12.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.12.3/download"
+              ],
+              "strip_prefix": "hashbrown-0.12.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hashbrown-0.12.3.bazel"
+            }
+          },
+          "rules_rust_prost__hashbrown-0.14.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.14.5/download"
+              ],
+              "strip_prefix": "hashbrown-0.14.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hashbrown-0.14.5.bazel"
+            }
+          },
+          "rules_rust_prost__heck-0.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.5.0/download"
+              ],
+              "strip_prefix": "heck-0.5.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.heck-0.5.0.bazel"
+            }
+          },
+          "rules_rust_prost__hermit-abi-0.3.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.3.9/download"
+              ],
+              "strip_prefix": "hermit-abi-0.3.9",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hermit-abi-0.3.9.bazel"
+            }
+          },
+          "rules_rust_prost__http-1.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/http/1.1.0/download"
+              ],
+              "strip_prefix": "http-1.1.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.http-1.1.0.bazel"
+            }
+          },
+          "rules_rust_prost__http-body-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/http-body/1.0.1/download"
+              ],
+              "strip_prefix": "http-body-1.0.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.http-body-1.0.1.bazel"
+            }
+          },
+          "rules_rust_prost__http-body-util-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/http-body-util/0.1.2/download"
+              ],
+              "strip_prefix": "http-body-util-0.1.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.http-body-util-0.1.2.bazel"
+            }
+          },
+          "rules_rust_prost__httparse-1.9.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httparse/1.9.4/download"
+              ],
+              "strip_prefix": "httparse-1.9.4",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.httparse-1.9.4.bazel"
+            }
+          },
+          "rules_rust_prost__httpdate-1.0.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httpdate/1.0.3/download"
+              ],
+              "strip_prefix": "httpdate-1.0.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.httpdate-1.0.3.bazel"
+            }
+          },
+          "rules_rust_prost__hyper-1.4.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hyper/1.4.1/download"
+              ],
+              "strip_prefix": "hyper-1.4.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hyper-1.4.1.bazel"
+            }
+          },
+          "rules_rust_prost__hyper-timeout-0.5.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hyper-timeout/0.5.1/download"
+              ],
+              "strip_prefix": "hyper-timeout-0.5.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hyper-timeout-0.5.1.bazel"
+            }
+          },
+          "rules_rust_prost__hyper-util-0.1.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hyper-util/0.1.7/download"
+              ],
+              "strip_prefix": "hyper-util-0.1.7",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hyper-util-0.1.7.bazel"
+            }
+          },
+          "rules_rust_prost__indexmap-1.9.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/1.9.3/download"
+              ],
+              "strip_prefix": "indexmap-1.9.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.indexmap-1.9.3.bazel"
+            }
+          },
+          "rules_rust_prost__indexmap-2.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/2.4.0/download"
+              ],
+              "strip_prefix": "indexmap-2.4.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.indexmap-2.4.0.bazel"
+            }
+          },
+          "rules_rust_prost__itertools-0.13.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.13.0/download"
+              ],
+              "strip_prefix": "itertools-0.13.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.itertools-0.13.0.bazel"
+            }
+          },
+          "rules_rust_prost__itoa-1.0.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itoa/1.0.11/download"
+              ],
+              "strip_prefix": "itoa-1.0.11",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.itoa-1.0.11.bazel"
+            }
+          },
+          "rules_rust_prost__libc-0.2.158": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.158/download"
+              ],
+              "strip_prefix": "libc-0.2.158",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.libc-0.2.158.bazel"
+            }
+          },
+          "rules_rust_prost__linux-raw-sys-0.4.14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.4.14/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.4.14",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.linux-raw-sys-0.4.14.bazel"
+            }
+          },
+          "rules_rust_prost__lock_api-0.4.12": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lock_api/0.4.12/download"
+              ],
+              "strip_prefix": "lock_api-0.4.12",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.lock_api-0.4.12.bazel"
+            }
+          },
+          "rules_rust_prost__log-0.4.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.22/download"
+              ],
+              "strip_prefix": "log-0.4.22",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.log-0.4.22.bazel"
+            }
+          },
+          "rules_rust_prost__matchit-0.7.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/matchit/0.7.3/download"
+              ],
+              "strip_prefix": "matchit-0.7.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.matchit-0.7.3.bazel"
+            }
+          },
+          "rules_rust_prost__memchr-2.7.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.7.4/download"
+              ],
+              "strip_prefix": "memchr-2.7.4",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.memchr-2.7.4.bazel"
+            }
+          },
+          "rules_rust_prost__mime-0.3.17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mime/0.3.17/download"
+              ],
+              "strip_prefix": "mime-0.3.17",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.mime-0.3.17.bazel"
+            }
+          },
+          "rules_rust_prost__miniz_oxide-0.7.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/miniz_oxide/0.7.4/download"
+              ],
+              "strip_prefix": "miniz_oxide-0.7.4",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.miniz_oxide-0.7.4.bazel"
+            }
+          },
+          "rules_rust_prost__mio-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mio/1.0.2/download"
+              ],
+              "strip_prefix": "mio-1.0.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.mio-1.0.2.bazel"
+            }
+          },
+          "rules_rust_prost__multimap-0.10.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/multimap/0.10.0/download"
+              ],
+              "strip_prefix": "multimap-0.10.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.multimap-0.10.0.bazel"
+            }
+          },
+          "rules_rust_prost__object-0.36.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/object/0.36.3/download"
+              ],
+              "strip_prefix": "object-0.36.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.object-0.36.3.bazel"
+            }
+          },
+          "rules_rust_prost__once_cell-1.19.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.19.0/download"
+              ],
+              "strip_prefix": "once_cell-1.19.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.once_cell-1.19.0.bazel"
+            }
+          },
+          "rules_rust_prost__parking_lot-0.12.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot/0.12.3/download"
+              ],
+              "strip_prefix": "parking_lot-0.12.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.parking_lot-0.12.3.bazel"
+            }
+          },
+          "rules_rust_prost__parking_lot_core-0.9.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot_core/0.9.10/download"
+              ],
+              "strip_prefix": "parking_lot_core-0.9.10",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.parking_lot_core-0.9.10.bazel"
+            }
+          },
+          "rules_rust_prost__percent-encoding-2.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/percent-encoding/2.3.1/download"
+              ],
+              "strip_prefix": "percent-encoding-2.3.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.percent-encoding-2.3.1.bazel"
+            }
+          },
+          "rules_rust_prost__petgraph-0.6.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/petgraph/0.6.5/download"
+              ],
+              "strip_prefix": "petgraph-0.6.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.petgraph-0.6.5.bazel"
+            }
+          },
+          "rules_rust_prost__pin-project-1.1.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project/1.1.5/download"
+              ],
+              "strip_prefix": "pin-project-1.1.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-project-1.1.5.bazel"
+            }
+          },
+          "rules_rust_prost__pin-project-internal-1.1.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project-internal/1.1.5/download"
+              ],
+              "strip_prefix": "pin-project-internal-1.1.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-project-internal-1.1.5.bazel"
+            }
+          },
+          "rules_rust_prost__pin-project-lite-0.2.14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project-lite/0.2.14/download"
+              ],
+              "strip_prefix": "pin-project-lite-0.2.14",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-project-lite-0.2.14.bazel"
+            }
+          },
+          "rules_rust_prost__pin-utils-0.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-utils/0.1.0/download"
+              ],
+              "strip_prefix": "pin-utils-0.1.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-utils-0.1.0.bazel"
+            }
+          },
+          "rules_rust_prost__ppv-lite86-0.2.20": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ppv-lite86/0.2.20/download"
+              ],
+              "strip_prefix": "ppv-lite86-0.2.20",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.ppv-lite86-0.2.20.bazel"
+            }
+          },
+          "rules_rust_prost__prettyplease-0.2.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prettyplease/0.2.22/download"
+              ],
+              "strip_prefix": "prettyplease-0.2.22",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prettyplease-0.2.22.bazel"
+            }
+          },
+          "rules_rust_prost__proc-macro2-1.0.86": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.86/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.86",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.proc-macro2-1.0.86.bazel"
+            }
+          },
+          "rules_rust_prost__prost-0.13.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prost/0.13.1/download"
+              ],
+              "strip_prefix": "prost-0.13.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-0.13.1.bazel"
+            }
+          },
+          "rules_rust_prost__prost-build-0.13.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5bb182580f71dd070f88d01ce3de9f4da5021db7115d2e1c3605a754153b77c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prost-build/0.13.1/download"
+              ],
+              "strip_prefix": "prost-build-0.13.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-build-0.13.1.bazel"
+            }
+          },
+          "rules_rust_prost__prost-derive-0.13.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prost-derive/0.13.1/download"
+              ],
+              "strip_prefix": "prost-derive-0.13.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-derive-0.13.1.bazel"
+            }
+          },
+          "rules_rust_prost__prost-types-0.13.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cee5168b05f49d4b0ca581206eb14a7b22fafd963efe729ac48eb03266e25cc2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prost-types/0.13.1/download"
+              ],
+              "strip_prefix": "prost-types-0.13.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-types-0.13.1.bazel"
+            }
+          },
+          "rules_rust_prost__protoc-gen-prost-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "77eb17a7657a703f30cb9b7ba4d981e4037b8af2d819ab0077514b0bef537406",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/protoc-gen-prost/0.4.0/download"
+              ],
+              "strip_prefix": "protoc-gen-prost-0.4.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.protoc-gen-prost-0.4.0.bazel"
+            }
+          },
+          "rules_rust_prost__protoc-gen-tonic-0.4.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6ab6a0d73a0914752ed8fd7cc51afe169e28da87be3efef292de5676cc527634",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/protoc-gen-tonic/0.4.1/download"
+              ],
+              "strip_prefix": "protoc-gen-tonic-0.4.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.protoc-gen-tonic-0.4.1.bazel"
+            }
+          },
+          "rules_rust_prost__quote-1.0.37": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.37/download"
+              ],
+              "strip_prefix": "quote-1.0.37",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.quote-1.0.37.bazel"
+            }
+          },
+          "rules_rust_prost__rand-0.8.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand/0.8.5/download"
+              ],
+              "strip_prefix": "rand-0.8.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rand-0.8.5.bazel"
+            }
+          },
+          "rules_rust_prost__rand_chacha-0.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
+              ],
+              "strip_prefix": "rand_chacha-0.3.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
+            }
+          },
+          "rules_rust_prost__rand_core-0.6.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_core/0.6.4/download"
+              ],
+              "strip_prefix": "rand_core-0.6.4",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
+            }
+          },
+          "rules_rust_prost__redox_syscall-0.5.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.5.3/download"
+              ],
+              "strip_prefix": "redox_syscall-0.5.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.redox_syscall-0.5.3.bazel"
+            }
+          },
+          "rules_rust_prost__regex-1.10.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.10.6/download"
+              ],
+              "strip_prefix": "regex-1.10.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.regex-1.10.6.bazel"
+            }
+          },
+          "rules_rust_prost__regex-automata-0.4.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.4.7/download"
+              ],
+              "strip_prefix": "regex-automata-0.4.7",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.regex-automata-0.4.7.bazel"
+            }
+          },
+          "rules_rust_prost__regex-syntax-0.8.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.8.4/download"
+              ],
+              "strip_prefix": "regex-syntax-0.8.4",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.regex-syntax-0.8.4.bazel"
+            }
+          },
+          "rules_rust_prost__rustc-demangle-0.1.24": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-demangle/0.1.24/download"
+              ],
+              "strip_prefix": "rustc-demangle-0.1.24",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rustc-demangle-0.1.24.bazel"
+            }
+          },
+          "rules_rust_prost__rustix-0.38.34": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.38.34/download"
+              ],
+              "strip_prefix": "rustix-0.38.34",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rustix-0.38.34.bazel"
+            }
+          },
+          "rules_rust_prost__rustversion-1.0.17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustversion/1.0.17/download"
+              ],
+              "strip_prefix": "rustversion-1.0.17",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rustversion-1.0.17.bazel"
+            }
+          },
+          "rules_rust_prost__scopeguard-1.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scopeguard/1.2.0/download"
+              ],
+              "strip_prefix": "scopeguard-1.2.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.scopeguard-1.2.0.bazel"
+            }
+          },
+          "rules_rust_prost__serde-1.0.209": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde/1.0.209/download"
+              ],
+              "strip_prefix": "serde-1.0.209",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.serde-1.0.209.bazel"
+            }
+          },
+          "rules_rust_prost__serde_derive-1.0.209": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_derive/1.0.209/download"
+              ],
+              "strip_prefix": "serde_derive-1.0.209",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.serde_derive-1.0.209.bazel"
+            }
+          },
+          "rules_rust_prost__shlex-1.3.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/shlex/1.3.0/download"
+              ],
+              "strip_prefix": "shlex-1.3.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.shlex-1.3.0.bazel"
+            }
+          },
+          "rules_rust_prost__signal-hook-registry-1.4.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/signal-hook-registry/1.4.2/download"
+              ],
+              "strip_prefix": "signal-hook-registry-1.4.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.signal-hook-registry-1.4.2.bazel"
+            }
+          },
+          "rules_rust_prost__slab-0.4.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/slab/0.4.9/download"
+              ],
+              "strip_prefix": "slab-0.4.9",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.slab-0.4.9.bazel"
+            }
+          },
+          "rules_rust_prost__smallvec-1.13.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smallvec/1.13.2/download"
+              ],
+              "strip_prefix": "smallvec-1.13.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.smallvec-1.13.2.bazel"
+            }
+          },
+          "rules_rust_prost__socket2-0.5.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/socket2/0.5.7/download"
+              ],
+              "strip_prefix": "socket2-0.5.7",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.socket2-0.5.7.bazel"
+            }
+          },
+          "rules_rust_prost__syn-2.0.76": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.76/download"
+              ],
+              "strip_prefix": "syn-2.0.76",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.syn-2.0.76.bazel"
+            }
+          },
+          "rules_rust_prost__sync_wrapper-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sync_wrapper/0.1.2/download"
+              ],
+              "strip_prefix": "sync_wrapper-0.1.2",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.sync_wrapper-0.1.2.bazel"
+            }
+          },
+          "rules_rust_prost__sync_wrapper-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sync_wrapper/1.0.1/download"
+              ],
+              "strip_prefix": "sync_wrapper-1.0.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.sync_wrapper-1.0.1.bazel"
+            }
+          },
+          "rules_rust_prost__tempfile-3.12.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tempfile/3.12.0/download"
+              ],
+              "strip_prefix": "tempfile-3.12.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tempfile-3.12.0.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-1.39.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio/1.39.3/download"
+              ],
+              "strip_prefix": "tokio-1.39.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-1.39.3.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-macros-2.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-macros/2.4.0/download"
+              ],
+              "strip_prefix": "tokio-macros-2.4.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-macros-2.4.0.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-stream-0.1.15": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-stream/0.1.15/download"
+              ],
+              "strip_prefix": "tokio-stream-0.1.15",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-stream-0.1.15.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-util-0.7.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-util/0.7.11/download"
+              ],
+              "strip_prefix": "tokio-util-0.7.11",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-util-0.7.11.bazel"
+            }
+          },
+          "rules_rust_prost__tonic-0.12.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tonic/0.12.1/download"
+              ],
+              "strip_prefix": "tonic-0.12.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tonic-0.12.1.bazel"
+            }
+          },
+          "rules_rust_prost__tonic-build-0.12.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "568392c5a2bd0020723e3f387891176aabafe36fd9fcd074ad309dfa0c8eb964",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tonic-build/0.12.1/download"
+              ],
+              "strip_prefix": "tonic-build-0.12.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tonic-build-0.12.1.bazel"
+            }
+          },
+          "rules_rust_prost__tower-0.4.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tower/0.4.13/download"
+              ],
+              "strip_prefix": "tower-0.4.13",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tower-0.4.13.bazel"
+            }
+          },
+          "rules_rust_prost__tower-layer-0.3.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tower-layer/0.3.3/download"
+              ],
+              "strip_prefix": "tower-layer-0.3.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tower-layer-0.3.3.bazel"
+            }
+          },
+          "rules_rust_prost__tower-service-0.3.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tower-service/0.3.3/download"
+              ],
+              "strip_prefix": "tower-service-0.3.3",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tower-service-0.3.3.bazel"
+            }
+          },
+          "rules_rust_prost__tracing-0.1.40": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing/0.1.40/download"
+              ],
+              "strip_prefix": "tracing-0.1.40",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tracing-0.1.40.bazel"
+            }
+          },
+          "rules_rust_prost__tracing-attributes-0.1.27": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-attributes/0.1.27/download"
+              ],
+              "strip_prefix": "tracing-attributes-0.1.27",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tracing-attributes-0.1.27.bazel"
+            }
+          },
+          "rules_rust_prost__tracing-core-0.1.32": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-core/0.1.32/download"
+              ],
+              "strip_prefix": "tracing-core-0.1.32",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tracing-core-0.1.32.bazel"
+            }
+          },
+          "rules_rust_prost__try-lock-0.2.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/try-lock/0.2.5/download"
+              ],
+              "strip_prefix": "try-lock-0.2.5",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.try-lock-0.2.5.bazel"
+            }
+          },
+          "rules_rust_prost__unicode-ident-1.0.12": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.12/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.12",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.unicode-ident-1.0.12.bazel"
+            }
+          },
+          "rules_rust_prost__want-0.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/want/0.3.1/download"
+              ],
+              "strip_prefix": "want-0.3.1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.want-0.3.1.bazel"
+            }
+          },
+          "rules_rust_prost__wasi-0.11.0-wasi-snapshot-preview1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
+              ],
+              "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
+            }
+          },
+          "rules_rust_prost__windows-sys-0.52.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.52.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.52.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows-sys-0.52.0.bazel"
+            }
+          },
+          "rules_rust_prost__windows-sys-0.59.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.59.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.59.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows-sys-0.59.0.bazel"
+            }
+          },
+          "rules_rust_prost__windows-targets-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.52.6/download"
+              ],
+              "strip_prefix": "windows-targets-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows-targets-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_aarch64_gnullvm-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_aarch64_msvc-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_aarch64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_i686_gnu-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_i686_gnu-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_i686_gnullvm-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_i686_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_i686_msvc-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_i686_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_x86_64_gnu-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_gnu-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_x86_64_gnullvm-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_x86_64_msvc-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.52.6",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__zerocopy-0.7.35": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/zerocopy/0.7.35/download"
+              ],
+              "strip_prefix": "zerocopy-0.7.35",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.zerocopy-0.7.35.bazel"
+            }
+          },
+          "rules_rust_prost__zerocopy-derive-0.7.35": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/zerocopy-derive/0.7.35/download"
+              ],
+              "strip_prefix": "zerocopy-derive-0.7.35",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.zerocopy-derive-0.7.35.bazel"
+            }
+          },
+          "rules_rust_prost__heck": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "integrity": "sha256-IwTgCYP4f/s4tVtES147YKiEtdMMD8p9gv4zRJu+Veo=",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/heck-0.5.0.crate"
+              ],
+              "strip_prefix": "heck-0.5.0",
+              "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.heck-0.5.0.bazel"
+            }
+          },
+          "rules_rust_proto__autocfg-1.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
+              ],
+              "strip_prefix": "autocfg-1.1.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
+            }
+          },
+          "rules_rust_proto__base64-0.9.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/base64/0.9.3/download"
+              ],
+              "strip_prefix": "base64-0.9.3",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.base64-0.9.3.bazel"
+            }
+          },
+          "rules_rust_proto__bitflags-1.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
+              ],
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
+            }
+          },
+          "rules_rust_proto__byteorder-1.4.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/byteorder/1.4.3/download"
+              ],
+              "strip_prefix": "byteorder-1.4.3",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.byteorder-1.4.3.bazel"
+            }
+          },
+          "rules_rust_proto__bytes-0.4.12": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bytes/0.4.12/download"
+              ],
+              "strip_prefix": "bytes-0.4.12",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.bytes-0.4.12.bazel"
+            }
+          },
+          "rules_rust_proto__cfg-if-0.1.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/0.1.10/download"
+              ],
+              "strip_prefix": "cfg-if-0.1.10",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.cfg-if-0.1.10.bazel"
+            }
+          },
+          "rules_rust_proto__cfg-if-1.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "rules_rust_proto__cloudabi-0.0.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cloudabi/0.0.3/download"
+              ],
+              "strip_prefix": "cloudabi-0.0.3",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.cloudabi-0.0.3.bazel"
+            }
+          },
+          "rules_rust_proto__crossbeam-deque-0.7.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-deque/0.7.4/download"
+              ],
+              "strip_prefix": "crossbeam-deque-0.7.4",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.crossbeam-deque-0.7.4.bazel"
+            }
+          },
+          "rules_rust_proto__crossbeam-epoch-0.8.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-epoch/0.8.2/download"
+              ],
+              "strip_prefix": "crossbeam-epoch-0.8.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.crossbeam-epoch-0.8.2.bazel"
+            }
+          },
+          "rules_rust_proto__crossbeam-queue-0.2.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-queue/0.2.3/download"
+              ],
+              "strip_prefix": "crossbeam-queue-0.2.3",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.crossbeam-queue-0.2.3.bazel"
+            }
+          },
+          "rules_rust_proto__crossbeam-utils-0.7.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-utils/0.7.2/download"
+              ],
+              "strip_prefix": "crossbeam-utils-0.7.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.crossbeam-utils-0.7.2.bazel"
+            }
+          },
+          "rules_rust_proto__fnv-1.0.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fnv/1.0.7/download"
+              ],
+              "strip_prefix": "fnv-1.0.7",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
+            }
+          },
+          "rules_rust_proto__fuchsia-zircon-0.3.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fuchsia-zircon/0.3.3/download"
+              ],
+              "strip_prefix": "fuchsia-zircon-0.3.3",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.fuchsia-zircon-0.3.3.bazel"
+            }
+          },
+          "rules_rust_proto__fuchsia-zircon-sys-0.3.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fuchsia-zircon-sys/0.3.3/download"
+              ],
+              "strip_prefix": "fuchsia-zircon-sys-0.3.3",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.fuchsia-zircon-sys-0.3.3.bazel"
+            }
+          },
+          "rules_rust_proto__futures-0.1.31": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures/0.1.31/download"
+              ],
+              "strip_prefix": "futures-0.1.31",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.futures-0.1.31.bazel"
+            }
+          },
+          "rules_rust_proto__futures-cpupool-0.1.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-cpupool/0.1.8/download"
+              ],
+              "strip_prefix": "futures-cpupool-0.1.8",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.futures-cpupool-0.1.8.bazel"
+            }
+          },
+          "rules_rust_proto__grpc-0.6.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2aaf1d741fe6f3413f1f9f71b99f5e4e26776d563475a8a53ce53a73a8534c1d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/grpc/0.6.2/download"
+              ],
+              "strip_prefix": "grpc-0.6.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.grpc-0.6.2.bazel"
+            }
+          },
+          "rules_rust_proto__grpc-compiler-0.6.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "907274ce8ee7b40a0d0b0db09022ea22846a47cfb1fc8ad2c983c70001b4ffb1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/grpc-compiler/0.6.2/download"
+              ],
+              "strip_prefix": "grpc-compiler-0.6.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.grpc-compiler-0.6.2.bazel"
+            }
+          },
+          "rules_rust_proto__hermit-abi-0.2.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.2.6/download"
+              ],
+              "strip_prefix": "hermit-abi-0.2.6",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.hermit-abi-0.2.6.bazel"
+            }
+          },
+          "rules_rust_proto__httpbis-0.7.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7689cfa896b2a71da4f16206af167542b75d242b6906313e53857972a92d5614",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httpbis/0.7.0/download"
+              ],
+              "strip_prefix": "httpbis-0.7.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.httpbis-0.7.0.bazel"
+            }
+          },
+          "rules_rust_proto__iovec-0.1.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/iovec/0.1.4/download"
+              ],
+              "strip_prefix": "iovec-0.1.4",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.iovec-0.1.4.bazel"
+            }
+          },
+          "rules_rust_proto__kernel32-sys-0.2.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/kernel32-sys/0.2.2/download"
+              ],
+              "strip_prefix": "kernel32-sys-0.2.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.kernel32-sys-0.2.2.bazel"
+            }
+          },
+          "rules_rust_proto__lazy_static-1.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lazy_static/1.4.0/download"
+              ],
+              "strip_prefix": "lazy_static-1.4.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
+            }
+          },
+          "rules_rust_proto__libc-0.2.139": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.139/download"
+              ],
+              "strip_prefix": "libc-0.2.139",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.libc-0.2.139.bazel"
+            }
+          },
+          "rules_rust_proto__lock_api-0.3.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lock_api/0.3.4/download"
+              ],
+              "strip_prefix": "lock_api-0.3.4",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.lock_api-0.3.4.bazel"
+            }
+          },
+          "rules_rust_proto__log-0.3.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.3.9/download"
+              ],
+              "strip_prefix": "log-0.3.9",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.log-0.3.9.bazel"
+            }
+          },
+          "rules_rust_proto__log-0.4.17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.17/download"
+              ],
+              "strip_prefix": "log-0.4.17",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.log-0.4.17.bazel"
+            }
+          },
+          "rules_rust_proto__maybe-uninit-2.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/maybe-uninit/2.0.0/download"
+              ],
+              "strip_prefix": "maybe-uninit-2.0.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.maybe-uninit-2.0.0.bazel"
+            }
+          },
+          "rules_rust_proto__memoffset-0.5.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memoffset/0.5.6/download"
+              ],
+              "strip_prefix": "memoffset-0.5.6",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.memoffset-0.5.6.bazel"
+            }
+          },
+          "rules_rust_proto__mio-0.6.23": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mio/0.6.23/download"
+              ],
+              "strip_prefix": "mio-0.6.23",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.mio-0.6.23.bazel"
+            }
+          },
+          "rules_rust_proto__mio-uds-0.6.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mio-uds/0.6.8/download"
+              ],
+              "strip_prefix": "mio-uds-0.6.8",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.mio-uds-0.6.8.bazel"
+            }
+          },
+          "rules_rust_proto__miow-0.2.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/miow/0.2.2/download"
+              ],
+              "strip_prefix": "miow-0.2.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.miow-0.2.2.bazel"
+            }
+          },
+          "rules_rust_proto__net2-0.2.38": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/net2/0.2.38/download"
+              ],
+              "strip_prefix": "net2-0.2.38",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.net2-0.2.38.bazel"
+            }
+          },
+          "rules_rust_proto__num_cpus-1.15.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num_cpus/1.15.0/download"
+              ],
+              "strip_prefix": "num_cpus-1.15.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.num_cpus-1.15.0.bazel"
+            }
+          },
+          "rules_rust_proto__parking_lot-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot/0.9.0/download"
+              ],
+              "strip_prefix": "parking_lot-0.9.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.parking_lot-0.9.0.bazel"
+            }
+          },
+          "rules_rust_proto__parking_lot_core-0.6.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bda66b810a62be75176a80873726630147a5ca780cd33921e0b5709033e66b0a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot_core/0.6.3/download"
+              ],
+              "strip_prefix": "parking_lot_core-0.6.3",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.parking_lot_core-0.6.3.bazel"
+            }
+          },
+          "rules_rust_proto__protobuf-2.8.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "patch_args": [
+                "-p1"
+              ],
+              "patches": [
+                "@@rules_rust~//proto/protobuf/3rdparty/patches:protobuf-2.8.2.patch"
+              ],
+              "sha256": "70731852eec72c56d11226c8a5f96ad5058a3dab73647ca5f7ee351e464f2571",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/protobuf/2.8.2/download"
+              ],
+              "strip_prefix": "protobuf-2.8.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.protobuf-2.8.2.bazel"
+            }
+          },
+          "rules_rust_proto__protobuf-codegen-2.8.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3d74b9cbbf2ac9a7169c85a3714ec16c51ee9ec7cfd511549527e9a7df720795",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/protobuf-codegen/2.8.2/download"
+              ],
+              "strip_prefix": "protobuf-codegen-2.8.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.protobuf-codegen-2.8.2.bazel"
+            }
+          },
+          "rules_rust_proto__redox_syscall-0.1.57": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.1.57/download"
+              ],
+              "strip_prefix": "redox_syscall-0.1.57",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.redox_syscall-0.1.57.bazel"
+            }
+          },
+          "rules_rust_proto__rustc_version-0.2.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc_version/0.2.3/download"
+              ],
+              "strip_prefix": "rustc_version-0.2.3",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.rustc_version-0.2.3.bazel"
+            }
+          },
+          "rules_rust_proto__safemem-0.3.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/safemem/0.3.3/download"
+              ],
+              "strip_prefix": "safemem-0.3.3",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.safemem-0.3.3.bazel"
+            }
+          },
+          "rules_rust_proto__scoped-tls-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scoped-tls/0.1.2/download"
+              ],
+              "strip_prefix": "scoped-tls-0.1.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.scoped-tls-0.1.2.bazel"
+            }
+          },
+          "rules_rust_proto__scopeguard-1.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scopeguard/1.1.0/download"
+              ],
+              "strip_prefix": "scopeguard-1.1.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.scopeguard-1.1.0.bazel"
+            }
+          },
+          "rules_rust_proto__semver-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/semver/0.9.0/download"
+              ],
+              "strip_prefix": "semver-0.9.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.semver-0.9.0.bazel"
+            }
+          },
+          "rules_rust_proto__semver-parser-0.7.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/semver-parser/0.7.0/download"
+              ],
+              "strip_prefix": "semver-parser-0.7.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.semver-parser-0.7.0.bazel"
+            }
+          },
+          "rules_rust_proto__slab-0.3.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/slab/0.3.0/download"
+              ],
+              "strip_prefix": "slab-0.3.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.slab-0.3.0.bazel"
+            }
+          },
+          "rules_rust_proto__slab-0.4.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/slab/0.4.7/download"
+              ],
+              "strip_prefix": "slab-0.4.7",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.slab-0.4.7.bazel"
+            }
+          },
+          "rules_rust_proto__smallvec-0.6.14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smallvec/0.6.14/download"
+              ],
+              "strip_prefix": "smallvec-0.6.14",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.smallvec-0.6.14.bazel"
+            }
+          },
+          "rules_rust_proto__tls-api-0.1.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "049c03787a0595182357fbd487577947f4351b78ce20c3668f6d49f17feb13d1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tls-api/0.1.22/download"
+              ],
+              "strip_prefix": "tls-api-0.1.22",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tls-api-0.1.22.bazel"
+            }
+          },
+          "rules_rust_proto__tls-api-stub-0.1.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c9a0cc8c149724db9de7d73a0e1bc80b1a74f5394f08c6f301e11f9c35fa061e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tls-api-stub/0.1.22/download"
+              ],
+              "strip_prefix": "tls-api-stub-0.1.22",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tls-api-stub-0.1.22.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-0.1.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio/0.1.22/download"
+              ],
+              "strip_prefix": "tokio-0.1.22",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-0.1.22.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-codec-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-codec/0.1.2/download"
+              ],
+              "strip_prefix": "tokio-codec-0.1.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-codec-0.1.2.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-core-0.1.18": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "87b1395334443abca552f63d4f61d0486f12377c2ba8b368e523f89e828cffd4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-core/0.1.18/download"
+              ],
+              "strip_prefix": "tokio-core-0.1.18",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-core-0.1.18.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-current-thread-0.1.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-current-thread/0.1.7/download"
+              ],
+              "strip_prefix": "tokio-current-thread-0.1.7",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-current-thread-0.1.7.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-executor-0.1.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-executor/0.1.10/download"
+              ],
+              "strip_prefix": "tokio-executor-0.1.10",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-executor-0.1.10.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-fs-0.1.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-fs/0.1.7/download"
+              ],
+              "strip_prefix": "tokio-fs-0.1.7",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-fs-0.1.7.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-io-0.1.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-io/0.1.13/download"
+              ],
+              "strip_prefix": "tokio-io-0.1.13",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-io-0.1.13.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-reactor-0.1.12": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-reactor/0.1.12/download"
+              ],
+              "strip_prefix": "tokio-reactor-0.1.12",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-reactor-0.1.12.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-sync-0.1.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-sync/0.1.8/download"
+              ],
+              "strip_prefix": "tokio-sync-0.1.8",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-sync-0.1.8.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-tcp-0.1.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-tcp/0.1.4/download"
+              ],
+              "strip_prefix": "tokio-tcp-0.1.4",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-tcp-0.1.4.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-threadpool-0.1.18": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-threadpool/0.1.18/download"
+              ],
+              "strip_prefix": "tokio-threadpool-0.1.18",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-threadpool-0.1.18.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-timer-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6131e780037787ff1b3f8aad9da83bca02438b72277850dd6ad0d455e0e20efc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-timer/0.1.2/download"
+              ],
+              "strip_prefix": "tokio-timer-0.1.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-timer-0.1.2.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-timer-0.2.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-timer/0.2.13/download"
+              ],
+              "strip_prefix": "tokio-timer-0.2.13",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-timer-0.2.13.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-tls-api-0.1.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "68d0e040d5b1f4cfca70ec4f371229886a5de5bb554d272a4a8da73004a7b2c9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-tls-api/0.1.22/download"
+              ],
+              "strip_prefix": "tokio-tls-api-0.1.22",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-tls-api-0.1.22.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-udp-0.1.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-udp/0.1.6/download"
+              ],
+              "strip_prefix": "tokio-udp-0.1.6",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-udp-0.1.6.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-uds-0.1.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "65ae5d255ce739e8537221ed2942e0445f4b3b813daebac1c0050ddaaa3587f9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-uds/0.1.7/download"
+              ],
+              "strip_prefix": "tokio-uds-0.1.7",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-uds-0.1.7.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-uds-0.2.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-uds/0.2.7/download"
+              ],
+              "strip_prefix": "tokio-uds-0.2.7",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-uds-0.2.7.bazel"
+            }
+          },
+          "rules_rust_proto__unix_socket-0.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unix_socket/0.5.0/download"
+              ],
+              "strip_prefix": "unix_socket-0.5.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.unix_socket-0.5.0.bazel"
+            }
+          },
+          "rules_rust_proto__void-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/void/1.0.2/download"
+              ],
+              "strip_prefix": "void-1.0.2",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.void-1.0.2.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-0.2.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.2.8/download"
+              ],
+              "strip_prefix": "winapi-0.2.8",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-0.2.8.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-0.3.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-build-0.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-build/0.1.1/download"
+              ],
+              "strip_prefix": "winapi-build-0.1.1",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-build-0.1.1.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-i686-pc-windows-gnu-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_proto__ws2_32-sys-0.2.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ws2_32-sys/0.2.1/download"
+              ],
+              "strip_prefix": "ws2_32-sys-0.2.1",
+              "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.ws2_32-sys-0.2.1.bazel"
+            }
+          },
+          "llvm-raw": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/llvm-project-14.0.6.src.tar.xz"
+              ],
+              "strip_prefix": "llvm-project-14.0.6.src",
+              "sha256": "8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a",
+              "build_file_content": "# empty",
+              "patch_args": [
+                "-p1"
+              ],
+              "patches": [
+                "@@rules_rust~//bindgen/3rdparty/patches:llvm-project.cxx17.patch",
+                "@@rules_rust~//bindgen/3rdparty/patches:llvm-project.incompatible_disallow_empty_glob.patch"
+              ]
+            }
+          },
+          "rules_rust_bindgen__bindgen-cli-0.70.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "integrity": "sha256-Mz+eRtWNh1r7irkjwi27fmF4j1WtKPK12Yv5ENkL1ao=",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bindgen-cli/bindgen-cli-0.70.1.crate"
+              ],
+              "strip_prefix": "bindgen-cli-0.70.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty:BUILD.bindgen-cli.bazel"
+            }
+          },
+          "rules_rust_bindgen__aho-corasick-1.1.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.1.3/download"
+              ],
+              "strip_prefix": "aho-corasick-1.1.3",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.aho-corasick-1.1.3.bazel"
+            }
+          },
+          "rules_rust_bindgen__annotate-snippets-0.9.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/annotate-snippets/0.9.2/download"
+              ],
+              "strip_prefix": "annotate-snippets-0.9.2",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.annotate-snippets-0.9.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstream-0.6.15": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstream/0.6.15/download"
+              ],
+              "strip_prefix": "anstream-0.6.15",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstream-0.6.15.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-1.0.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle/1.0.8/download"
+              ],
+              "strip_prefix": "anstyle-1.0.8",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-1.0.8.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-parse-0.2.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-parse/0.2.5/download"
+              ],
+              "strip_prefix": "anstyle-parse-0.2.5",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-parse-0.2.5.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-query-1.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-query/1.1.1/download"
+              ],
+              "strip_prefix": "anstyle-query-1.1.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-query-1.1.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-wincon-3.0.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-wincon/3.0.4/download"
+              ],
+              "strip_prefix": "anstyle-wincon-3.0.4",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-wincon-3.0.4.bazel"
+            }
+          },
+          "rules_rust_bindgen__bindgen-0.70.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bindgen/0.70.1/download"
+              ],
+              "strip_prefix": "bindgen-0.70.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.bindgen-0.70.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__bitflags-2.6.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/2.6.0/download"
+              ],
+              "strip_prefix": "bitflags-2.6.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.bitflags-2.6.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__cexpr-0.6.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cexpr/0.6.0/download"
+              ],
+              "strip_prefix": "cexpr-0.6.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.cexpr-0.6.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__cfg-if-1.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__clang-sys-1.8.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clang-sys/1.8.1/download"
+              ],
+              "strip_prefix": "clang-sys-1.8.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clang-sys-1.8.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap-4.5.17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap/4.5.17/download"
+              ],
+              "strip_prefix": "clap-4.5.17",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap-4.5.17.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_builder-4.5.17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_builder/4.5.17/download"
+              ],
+              "strip_prefix": "clap_builder-4.5.17",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_builder-4.5.17.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_complete-4.5.26": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "205d5ef6d485fa47606b98b0ddc4ead26eb850aaa86abfb562a94fb3280ecba0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_complete/4.5.26/download"
+              ],
+              "strip_prefix": "clap_complete-4.5.26",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_complete-4.5.26.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_derive-4.5.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_derive/4.5.13/download"
+              ],
+              "strip_prefix": "clap_derive-4.5.13",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_derive-4.5.13.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_lex-0.7.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_lex/0.7.2/download"
+              ],
+              "strip_prefix": "clap_lex-0.7.2",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_lex-0.7.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__colorchoice-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/colorchoice/1.0.2/download"
+              ],
+              "strip_prefix": "colorchoice-1.0.2",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.colorchoice-1.0.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__either-1.13.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.13.0/download"
+              ],
+              "strip_prefix": "either-1.13.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.either-1.13.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__env_logger-0.10.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/env_logger/0.10.2/download"
+              ],
+              "strip_prefix": "env_logger-0.10.2",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.env_logger-0.10.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__glob-0.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/glob/0.3.1/download"
+              ],
+              "strip_prefix": "glob-0.3.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.glob-0.3.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__heck-0.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.5.0/download"
+              ],
+              "strip_prefix": "heck-0.5.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.heck-0.5.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__hermit-abi-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.4.0/download"
+              ],
+              "strip_prefix": "hermit-abi-0.4.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.hermit-abi-0.4.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__humantime-2.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/humantime/2.1.0/download"
+              ],
+              "strip_prefix": "humantime-2.1.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__is-terminal-0.4.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/is-terminal/0.4.13/download"
+              ],
+              "strip_prefix": "is-terminal-0.4.13",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.is-terminal-0.4.13.bazel"
+            }
+          },
+          "rules_rust_bindgen__is_terminal_polyfill-1.70.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/is_terminal_polyfill/1.70.1/download"
+              ],
+              "strip_prefix": "is_terminal_polyfill-1.70.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.is_terminal_polyfill-1.70.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__itertools-0.13.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.13.0/download"
+              ],
+              "strip_prefix": "itertools-0.13.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.itertools-0.13.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__libc-0.2.158": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.158/download"
+              ],
+              "strip_prefix": "libc-0.2.158",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.libc-0.2.158.bazel"
+            }
+          },
+          "rules_rust_bindgen__libloading-0.8.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libloading/0.8.5/download"
+              ],
+              "strip_prefix": "libloading-0.8.5",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.libloading-0.8.5.bazel"
+            }
+          },
+          "rules_rust_bindgen__log-0.4.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.22/download"
+              ],
+              "strip_prefix": "log-0.4.22",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.log-0.4.22.bazel"
+            }
+          },
+          "rules_rust_bindgen__memchr-2.7.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.7.4/download"
+              ],
+              "strip_prefix": "memchr-2.7.4",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.memchr-2.7.4.bazel"
+            }
+          },
+          "rules_rust_bindgen__minimal-lexical-0.2.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/minimal-lexical/0.2.1/download"
+              ],
+              "strip_prefix": "minimal-lexical-0.2.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.minimal-lexical-0.2.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__nom-7.1.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/nom/7.1.3/download"
+              ],
+              "strip_prefix": "nom-7.1.3",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.nom-7.1.3.bazel"
+            }
+          },
+          "rules_rust_bindgen__prettyplease-0.2.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prettyplease/0.2.22/download"
+              ],
+              "strip_prefix": "prettyplease-0.2.22",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.prettyplease-0.2.22.bazel"
+            }
+          },
+          "rules_rust_bindgen__proc-macro2-1.0.86": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.86/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.86",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.proc-macro2-1.0.86.bazel"
+            }
+          },
+          "rules_rust_bindgen__quote-1.0.37": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.37/download"
+              ],
+              "strip_prefix": "quote-1.0.37",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.quote-1.0.37.bazel"
+            }
+          },
+          "rules_rust_bindgen__regex-1.10.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.10.6/download"
+              ],
+              "strip_prefix": "regex-1.10.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.regex-1.10.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__regex-automata-0.4.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.4.7/download"
+              ],
+              "strip_prefix": "regex-automata-0.4.7",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.regex-automata-0.4.7.bazel"
+            }
+          },
+          "rules_rust_bindgen__regex-syntax-0.8.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.8.4/download"
+              ],
+              "strip_prefix": "regex-syntax-0.8.4",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.regex-syntax-0.8.4.bazel"
+            }
+          },
+          "rules_rust_bindgen__rustc-hash-1.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-hash/1.1.0/download"
+              ],
+              "strip_prefix": "rustc-hash-1.1.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.rustc-hash-1.1.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__shlex-1.3.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/shlex/1.3.0/download"
+              ],
+              "strip_prefix": "shlex-1.3.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.shlex-1.3.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__strsim-0.11.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.11.1/download"
+              ],
+              "strip_prefix": "strsim-0.11.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.strsim-0.11.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__syn-2.0.77": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.77/download"
+              ],
+              "strip_prefix": "syn-2.0.77",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.syn-2.0.77.bazel"
+            }
+          },
+          "rules_rust_bindgen__termcolor-1.4.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/termcolor/1.4.1/download"
+              ],
+              "strip_prefix": "termcolor-1.4.1",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.termcolor-1.4.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__unicode-ident-1.0.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.13/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.13",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.unicode-ident-1.0.13.bazel"
+            }
+          },
+          "rules_rust_bindgen__unicode-width-0.1.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-width/0.1.13/download"
+              ],
+              "strip_prefix": "unicode-width-0.1.13",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.unicode-width-0.1.13.bazel"
+            }
+          },
+          "rules_rust_bindgen__utf8parse-0.2.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/utf8parse/0.2.2/download"
+              ],
+              "strip_prefix": "utf8parse-0.2.2",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.utf8parse-0.2.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__winapi-0.3.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "rules_rust_bindgen__winapi-i686-pc-windows-gnu-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__winapi-util-0.1.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-util/0.1.9/download"
+              ],
+              "strip_prefix": "winapi-util-0.1.9",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-util-0.1.9.bazel"
+            }
+          },
+          "rules_rust_bindgen__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows-sys-0.52.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.52.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.52.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows-sys-0.52.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows-sys-0.59.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.59.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.59.0",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows-sys-0.59.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows-targets-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.52.6/download"
+              ],
+              "strip_prefix": "windows-targets-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows-targets-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_aarch64_gnullvm-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_aarch64_msvc-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_aarch64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_i686_gnu-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_i686_gnu-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_i686_gnullvm-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_i686_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_i686_msvc-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_i686_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_x86_64_gnu-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_x86_64_gnu-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_x86_64_gnullvm-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_x86_64_msvc-0.52.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.52.6",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_x86_64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__yansi-term-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/yansi-term/0.1.2/download"
+              ],
+              "strip_prefix": "yansi-term-0.1.2",
+              "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.yansi-term-0.1.2.bazel"
+            }
+          },
+          "rrra__aho-corasick-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
+              ],
+              "strip_prefix": "aho-corasick-1.0.2",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
+            }
+          },
+          "rrra__anstream-0.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstream/0.3.2/download"
+              ],
+              "strip_prefix": "anstream-0.3.2",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstream-0.3.2.bazel"
+            }
+          },
+          "rrra__anstyle-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle/1.0.1/download"
+              ],
+              "strip_prefix": "anstyle-1.0.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-1.0.1.bazel"
+            }
+          },
+          "rrra__anstyle-parse-0.2.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-parse/0.2.1/download"
+              ],
+              "strip_prefix": "anstyle-parse-0.2.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-parse-0.2.1.bazel"
+            }
+          },
+          "rrra__anstyle-query-1.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-query/1.0.0/download"
+              ],
+              "strip_prefix": "anstyle-query-1.0.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-query-1.0.0.bazel"
+            }
+          },
+          "rrra__anstyle-wincon-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-wincon/1.0.1/download"
+              ],
+              "strip_prefix": "anstyle-wincon-1.0.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-wincon-1.0.1.bazel"
+            }
+          },
+          "rrra__anyhow-1.0.71": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.71/download"
+              ],
+              "strip_prefix": "anyhow-1.0.71",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anyhow-1.0.71.bazel"
+            }
+          },
+          "rrra__bitflags-1.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
+              ],
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
+            }
+          },
+          "rrra__cc-1.0.79": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cc/1.0.79/download"
+              ],
+              "strip_prefix": "cc-1.0.79",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.cc-1.0.79.bazel"
+            }
+          },
+          "rrra__clap-4.3.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap/4.3.11/download"
+              ],
+              "strip_prefix": "clap-4.3.11",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.clap-4.3.11.bazel"
+            }
+          },
+          "rrra__clap_builder-4.3.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_builder/4.3.11/download"
+              ],
+              "strip_prefix": "clap_builder-4.3.11",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.clap_builder-4.3.11.bazel"
+            }
+          },
+          "rrra__clap_derive-4.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_derive/4.3.2/download"
+              ],
+              "strip_prefix": "clap_derive-4.3.2",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.clap_derive-4.3.2.bazel"
+            }
+          },
+          "rrra__clap_lex-0.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_lex/0.5.0/download"
+              ],
+              "strip_prefix": "clap_lex-0.5.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.clap_lex-0.5.0.bazel"
+            }
+          },
+          "rrra__colorchoice-1.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/colorchoice/1.0.0/download"
+              ],
+              "strip_prefix": "colorchoice-1.0.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.colorchoice-1.0.0.bazel"
+            }
+          },
+          "rrra__either-1.8.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.8.1/download"
+              ],
+              "strip_prefix": "either-1.8.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.either-1.8.1.bazel"
+            }
+          },
+          "rrra__env_logger-0.10.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/env_logger/0.10.0/download"
+              ],
+              "strip_prefix": "env_logger-0.10.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.env_logger-0.10.0.bazel"
+            }
+          },
+          "rrra__errno-0.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno/0.3.1/download"
+              ],
+              "strip_prefix": "errno-0.3.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.errno-0.3.1.bazel"
+            }
+          },
+          "rrra__errno-dragonfly-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
+              ],
+              "strip_prefix": "errno-dragonfly-0.1.2",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
+            }
+          },
+          "rrra__heck-0.4.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.4.1/download"
+              ],
+              "strip_prefix": "heck-0.4.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.heck-0.4.1.bazel"
+            }
+          },
+          "rrra__hermit-abi-0.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.3.2/download"
+              ],
+              "strip_prefix": "hermit-abi-0.3.2",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
+            }
+          },
+          "rrra__humantime-2.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/humantime/2.1.0/download"
+              ],
+              "strip_prefix": "humantime-2.1.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
+            }
+          },
+          "rrra__io-lifetimes-1.0.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
+              ],
+              "strip_prefix": "io-lifetimes-1.0.11",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
+            }
+          },
+          "rrra__is-terminal-0.4.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/is-terminal/0.4.7/download"
+              ],
+              "strip_prefix": "is-terminal-0.4.7",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.is-terminal-0.4.7.bazel"
+            }
+          },
+          "rrra__itertools-0.11.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.11.0/download"
+              ],
+              "strip_prefix": "itertools-0.11.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.itertools-0.11.0.bazel"
+            }
+          },
+          "rrra__itoa-1.0.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itoa/1.0.8/download"
+              ],
+              "strip_prefix": "itoa-1.0.8",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
+            }
+          },
+          "rrra__libc-0.2.147": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.147/download"
+              ],
+              "strip_prefix": "libc-0.2.147",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.libc-0.2.147.bazel"
+            }
+          },
+          "rrra__linux-raw-sys-0.3.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.3.8",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
+            }
+          },
+          "rrra__log-0.4.19": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.19/download"
+              ],
+              "strip_prefix": "log-0.4.19",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.log-0.4.19.bazel"
+            }
+          },
+          "rrra__memchr-2.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.5.0/download"
+              ],
+              "strip_prefix": "memchr-2.5.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
+            }
+          },
+          "rrra__once_cell-1.18.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.18.0/download"
+              ],
+              "strip_prefix": "once_cell-1.18.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
+            }
+          },
+          "rrra__proc-macro2-1.0.64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.64/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.64",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.proc-macro2-1.0.64.bazel"
+            }
+          },
+          "rrra__quote-1.0.29": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.29/download"
+              ],
+              "strip_prefix": "quote-1.0.29",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.quote-1.0.29.bazel"
+            }
+          },
+          "rrra__regex-1.9.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.9.1/download"
+              ],
+              "strip_prefix": "regex-1.9.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.regex-1.9.1.bazel"
+            }
+          },
+          "rrra__regex-automata-0.3.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.3.3/download"
+              ],
+              "strip_prefix": "regex-automata-0.3.3",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
+            }
+          },
+          "rrra__regex-syntax-0.7.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.7.4/download"
+              ],
+              "strip_prefix": "regex-syntax-0.7.4",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.regex-syntax-0.7.4.bazel"
+            }
+          },
+          "rrra__rustix-0.37.23": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.37.23/download"
+              ],
+              "strip_prefix": "rustix-0.37.23",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
+            }
+          },
+          "rrra__ryu-1.0.14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ryu/1.0.14/download"
+              ],
+              "strip_prefix": "ryu-1.0.14",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
+            }
+          },
+          "rrra__serde-1.0.171": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde/1.0.171/download"
+              ],
+              "strip_prefix": "serde-1.0.171",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.serde-1.0.171.bazel"
+            }
+          },
+          "rrra__serde_derive-1.0.171": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_derive/1.0.171/download"
+              ],
+              "strip_prefix": "serde_derive-1.0.171",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.serde_derive-1.0.171.bazel"
+            }
+          },
+          "rrra__serde_json-1.0.102": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_json/1.0.102/download"
+              ],
+              "strip_prefix": "serde_json-1.0.102",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.serde_json-1.0.102.bazel"
+            }
+          },
+          "rrra__strsim-0.10.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.10.0/download"
+              ],
+              "strip_prefix": "strsim-0.10.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
+            }
+          },
+          "rrra__syn-2.0.25": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.25/download"
+              ],
+              "strip_prefix": "syn-2.0.25",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.syn-2.0.25.bazel"
+            }
+          },
+          "rrra__termcolor-1.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/termcolor/1.2.0/download"
+              ],
+              "strip_prefix": "termcolor-1.2.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.termcolor-1.2.0.bazel"
+            }
+          },
+          "rrra__unicode-ident-1.0.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.10/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.10",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
+            }
+          },
+          "rrra__utf8parse-0.2.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/utf8parse/0.2.1/download"
+              ],
+              "strip_prefix": "utf8parse-0.2.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.utf8parse-0.2.1.bazel"
+            }
+          },
+          "rrra__winapi-0.3.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "rrra__winapi-i686-pc-windows-gnu-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rrra__winapi-util-0.1.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-util/0.1.5/download"
+              ],
+              "strip_prefix": "winapi-util-0.1.5",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
+            }
+          },
+          "rrra__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rrra__windows-sys-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.48.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.48.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
+            }
+          },
+          "rrra__windows-targets-0.48.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.48.1/download"
+              ],
+              "strip_prefix": "windows-targets-0.48.1",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
+            }
+          },
+          "rrra__windows_aarch64_gnullvm-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_aarch64_msvc-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.48.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_i686_gnu-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.48.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_i686_msvc-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.48.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_x86_64_gnu-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.48.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_x86_64_gnullvm-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_x86_64_msvc-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.48.0",
+              "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen_cli": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "08f61e21873f51e3059a8c7c3eef81ede7513d161cfc60751c7b2ffa6ed28270",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-cli/wasm-bindgen-cli-0.2.92.crate"
+              ],
+              "type": "tar.gz",
+              "strip_prefix": "wasm-bindgen-cli-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty:BUILD.wasm-bindgen-cli.bazel",
+              "patch_args": [
+                "-p1"
+              ],
+              "patches": [
+                "@@rules_rust~//wasm_bindgen/3rdparty/patches:resolver.patch"
+              ]
+            }
+          },
+          "rules_rust_wasm_bindgen__adler-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/adler/1.0.2/download"
+              ],
+              "strip_prefix": "adler-1.0.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.adler-1.0.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__aho-corasick-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
+              ],
+              "strip_prefix": "aho-corasick-1.0.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__alloc-no-stdlib-2.0.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/alloc-no-stdlib/2.0.4/download"
+              ],
+              "strip_prefix": "alloc-no-stdlib-2.0.4",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.alloc-no-stdlib-2.0.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__alloc-stdlib-0.2.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/alloc-stdlib/0.2.2/download"
+              ],
+              "strip_prefix": "alloc-stdlib-0.2.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.alloc-stdlib-0.2.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__android-tzdata-0.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/android-tzdata/0.1.1/download"
+              ],
+              "strip_prefix": "android-tzdata-0.1.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.android-tzdata-0.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__android_system_properties-0.1.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/android_system_properties/0.1.5/download"
+              ],
+              "strip_prefix": "android_system_properties-0.1.5",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.android_system_properties-0.1.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__anyhow-1.0.71": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.71/download"
+              ],
+              "strip_prefix": "anyhow-1.0.71",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.anyhow-1.0.71.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ascii-1.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ascii/1.1.0/download"
+              ],
+              "strip_prefix": "ascii-1.1.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ascii-1.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__assert_cmd-1.0.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c98233c6673d8601ab23e77eb38f999c51100d46c5703b17288c57fddf3a1ffe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/assert_cmd/1.0.8/download"
+              ],
+              "strip_prefix": "assert_cmd-1.0.8",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.assert_cmd-1.0.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__atty-0.2.14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/atty/0.2.14/download"
+              ],
+              "strip_prefix": "atty-0.2.14",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.atty-0.2.14.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__autocfg-1.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
+              ],
+              "strip_prefix": "autocfg-1.1.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__base64-0.13.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/base64/0.13.1/download"
+              ],
+              "strip_prefix": "base64-0.13.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.base64-0.13.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__base64-0.21.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/base64/0.21.5/download"
+              ],
+              "strip_prefix": "base64-0.21.5",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.base64-0.21.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__bitflags-1.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
+              ],
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__brotli-decompressor-2.5.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/brotli-decompressor/2.5.1/download"
+              ],
+              "strip_prefix": "brotli-decompressor-2.5.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.brotli-decompressor-2.5.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__bstr-0.2.17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bstr/0.2.17/download"
+              ],
+              "strip_prefix": "bstr-0.2.17",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.bstr-0.2.17.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__buf_redux-0.8.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/buf_redux/0.8.4/download"
+              ],
+              "strip_prefix": "buf_redux-0.8.4",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.buf_redux-0.8.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__bumpalo-3.13.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bumpalo/3.13.0/download"
+              ],
+              "strip_prefix": "bumpalo-3.13.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.bumpalo-3.13.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__cc-1.0.83": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cc/1.0.83/download"
+              ],
+              "strip_prefix": "cc-1.0.83",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.cc-1.0.83.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__cfg-if-1.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__chrono-0.4.26": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/chrono/0.4.26/download"
+              ],
+              "strip_prefix": "chrono-0.4.26",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.chrono-0.4.26.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__chunked_transfer-1.4.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/chunked_transfer/1.4.1/download"
+              ],
+              "strip_prefix": "chunked_transfer-1.4.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.chunked_transfer-1.4.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__core-foundation-sys-0.8.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/core-foundation-sys/0.8.4/download"
+              ],
+              "strip_prefix": "core-foundation-sys-0.8.4",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.core-foundation-sys-0.8.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crc32fast-1.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crc32fast/1.3.2/download"
+              ],
+              "strip_prefix": "crc32fast-1.3.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crc32fast-1.3.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crossbeam-channel-0.5.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-channel/0.5.8/download"
+              ],
+              "strip_prefix": "crossbeam-channel-0.5.8",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-channel-0.5.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crossbeam-deque-0.8.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-deque/0.8.3/download"
+              ],
+              "strip_prefix": "crossbeam-deque-0.8.3",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-deque-0.8.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crossbeam-epoch-0.9.15": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-epoch/0.9.15/download"
+              ],
+              "strip_prefix": "crossbeam-epoch-0.9.15",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-epoch-0.9.15.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crossbeam-utils-0.8.16": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-utils/0.8.16/download"
+              ],
+              "strip_prefix": "crossbeam-utils-0.8.16",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-utils-0.8.16.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__diff-0.1.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/diff/0.1.13/download"
+              ],
+              "strip_prefix": "diff-0.1.13",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.diff-0.1.13.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__difference-2.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/difference/2.0.0/download"
+              ],
+              "strip_prefix": "difference-2.0.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.difference-2.0.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__difflib-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/difflib/0.4.0/download"
+              ],
+              "strip_prefix": "difflib-0.4.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.difflib-0.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__doc-comment-0.3.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/doc-comment/0.3.3/download"
+              ],
+              "strip_prefix": "doc-comment-0.3.3",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.doc-comment-0.3.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__docopt-1.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7f3f119846c823f9eafcf953a8f6ffb6ed69bf6240883261a7f13b634579a51f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/docopt/1.1.1/download"
+              ],
+              "strip_prefix": "docopt-1.1.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.docopt-1.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__either-1.8.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.8.1/download"
+              ],
+              "strip_prefix": "either-1.8.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.either-1.8.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__env_logger-0.8.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/env_logger/0.8.4/download"
+              ],
+              "strip_prefix": "env_logger-0.8.4",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.env_logger-0.8.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__equivalent-1.0.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/equivalent/1.0.1/download"
+              ],
+              "strip_prefix": "equivalent-1.0.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__errno-0.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno/0.3.1/download"
+              ],
+              "strip_prefix": "errno-0.3.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.errno-0.3.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__errno-dragonfly-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
+              ],
+              "strip_prefix": "errno-dragonfly-0.1.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__fallible-iterator-0.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fallible-iterator/0.2.0/download"
+              ],
+              "strip_prefix": "fallible-iterator-0.2.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.fallible-iterator-0.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__fastrand-1.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fastrand/1.9.0/download"
+              ],
+              "strip_prefix": "fastrand-1.9.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.fastrand-1.9.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__filetime-0.2.21": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/filetime/0.2.21/download"
+              ],
+              "strip_prefix": "filetime-0.2.21",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.filetime-0.2.21.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__flate2-1.0.28": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/flate2/1.0.28/download"
+              ],
+              "strip_prefix": "flate2-1.0.28",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.flate2-1.0.28.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__float-cmp-0.8.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/float-cmp/0.8.0/download"
+              ],
+              "strip_prefix": "float-cmp-0.8.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.float-cmp-0.8.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__form_urlencoded-1.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/form_urlencoded/1.2.0/download"
+              ],
+              "strip_prefix": "form_urlencoded-1.2.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.form_urlencoded-1.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__getrandom-0.2.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/getrandom/0.2.10/download"
+              ],
+              "strip_prefix": "getrandom-0.2.10",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.getrandom-0.2.10.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__gimli-0.26.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gimli/0.26.2/download"
+              ],
+              "strip_prefix": "gimli-0.26.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.gimli-0.26.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__hashbrown-0.12.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.12.3/download"
+              ],
+              "strip_prefix": "hashbrown-0.12.3",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.hashbrown-0.12.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__hashbrown-0.14.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.14.0/download"
+              ],
+              "strip_prefix": "hashbrown-0.14.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.hashbrown-0.14.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__heck-0.3.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.3.3/download"
+              ],
+              "strip_prefix": "heck-0.3.3",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.heck-0.3.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__hermit-abi-0.1.19": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.1.19/download"
+              ],
+              "strip_prefix": "hermit-abi-0.1.19",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.hermit-abi-0.1.19.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__hermit-abi-0.3.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.3.2/download"
+              ],
+              "strip_prefix": "hermit-abi-0.3.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__httparse-1.8.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httparse/1.8.0/download"
+              ],
+              "strip_prefix": "httparse-1.8.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.httparse-1.8.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__httpdate-1.0.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httpdate/1.0.2/download"
+              ],
+              "strip_prefix": "httpdate-1.0.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.httpdate-1.0.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__humantime-2.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/humantime/2.1.0/download"
+              ],
+              "strip_prefix": "humantime-2.1.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__iana-time-zone-0.1.57": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/iana-time-zone/0.1.57/download"
+              ],
+              "strip_prefix": "iana-time-zone-0.1.57",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.iana-time-zone-0.1.57.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__iana-time-zone-haiku-0.1.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/iana-time-zone-haiku/0.1.2/download"
+              ],
+              "strip_prefix": "iana-time-zone-haiku-0.1.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.iana-time-zone-haiku-0.1.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__id-arena-2.2.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/id-arena/2.2.1/download"
+              ],
+              "strip_prefix": "id-arena-2.2.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.id-arena-2.2.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__idna-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/idna/0.4.0/download"
+              ],
+              "strip_prefix": "idna-0.4.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.idna-0.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__indexmap-1.9.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/1.9.3/download"
+              ],
+              "strip_prefix": "indexmap-1.9.3",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.indexmap-1.9.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__indexmap-2.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/2.0.0/download"
+              ],
+              "strip_prefix": "indexmap-2.0.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.indexmap-2.0.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__instant-0.1.12": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/instant/0.1.12/download"
+              ],
+              "strip_prefix": "instant-0.1.12",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.instant-0.1.12.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__io-lifetimes-1.0.11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
+              ],
+              "strip_prefix": "io-lifetimes-1.0.11",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__itertools-0.10.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.10.5/download"
+              ],
+              "strip_prefix": "itertools-0.10.5",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.itertools-0.10.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__itoa-1.0.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itoa/1.0.8/download"
+              ],
+              "strip_prefix": "itoa-1.0.8",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__js-sys-0.3.64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/js-sys/0.3.64/download"
+              ],
+              "strip_prefix": "js-sys-0.3.64",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.js-sys-0.3.64.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__lazy_static-1.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lazy_static/1.4.0/download"
+              ],
+              "strip_prefix": "lazy_static-1.4.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__leb128-0.2.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/leb128/0.2.5/download"
+              ],
+              "strip_prefix": "leb128-0.2.5",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.leb128-0.2.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__libc-0.2.150": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.150/download"
+              ],
+              "strip_prefix": "libc-0.2.150",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.libc-0.2.150.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__linux-raw-sys-0.3.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.3.8",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__log-0.4.19": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.19/download"
+              ],
+              "strip_prefix": "log-0.4.19",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.log-0.4.19.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__memchr-2.5.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.5.0/download"
+              ],
+              "strip_prefix": "memchr-2.5.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__memoffset-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memoffset/0.9.0/download"
+              ],
+              "strip_prefix": "memoffset-0.9.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.memoffset-0.9.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__mime-0.3.17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mime/0.3.17/download"
+              ],
+              "strip_prefix": "mime-0.3.17",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.mime-0.3.17.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__mime_guess-2.0.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mime_guess/2.0.4/download"
+              ],
+              "strip_prefix": "mime_guess-2.0.4",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.mime_guess-2.0.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__miniz_oxide-0.7.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/miniz_oxide/0.7.1/download"
+              ],
+              "strip_prefix": "miniz_oxide-0.7.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.miniz_oxide-0.7.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__multipart-0.18.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/multipart/0.18.0/download"
+              ],
+              "strip_prefix": "multipart-0.18.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.multipart-0.18.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__normalize-line-endings-0.3.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/normalize-line-endings/0.3.0/download"
+              ],
+              "strip_prefix": "normalize-line-endings-0.3.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.normalize-line-endings-0.3.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__num-traits-0.2.15": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-traits/0.2.15/download"
+              ],
+              "strip_prefix": "num-traits-0.2.15",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.num-traits-0.2.15.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__num_cpus-1.16.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num_cpus/1.16.0/download"
+              ],
+              "strip_prefix": "num_cpus-1.16.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.num_cpus-1.16.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__num_threads-0.1.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num_threads/0.1.6/download"
+              ],
+              "strip_prefix": "num_threads-0.1.6",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.num_threads-0.1.6.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__once_cell-1.18.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.18.0/download"
+              ],
+              "strip_prefix": "once_cell-1.18.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__percent-encoding-2.3.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/percent-encoding/2.3.0/download"
+              ],
+              "strip_prefix": "percent-encoding-2.3.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.percent-encoding-2.3.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ppv-lite86-0.2.17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ppv-lite86/0.2.17/download"
+              ],
+              "strip_prefix": "ppv-lite86-0.2.17",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ppv-lite86-0.2.17.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__predicates-1.0.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/predicates/1.0.8/download"
+              ],
+              "strip_prefix": "predicates-1.0.8",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.predicates-1.0.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__predicates-2.1.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/predicates/2.1.5/download"
+              ],
+              "strip_prefix": "predicates-2.1.5",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.predicates-2.1.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__predicates-core-1.0.6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/predicates-core/1.0.6/download"
+              ],
+              "strip_prefix": "predicates-core-1.0.6",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.predicates-core-1.0.6.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__predicates-tree-1.0.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/predicates-tree/1.0.9/download"
+              ],
+              "strip_prefix": "predicates-tree-1.0.9",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.predicates-tree-1.0.9.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__proc-macro2-1.0.64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.64/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.64",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.proc-macro2-1.0.64.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__quick-error-1.2.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quick-error/1.2.3/download"
+              ],
+              "strip_prefix": "quick-error-1.2.3",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.quick-error-1.2.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__quote-1.0.29": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.29/download"
+              ],
+              "strip_prefix": "quote-1.0.29",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.quote-1.0.29.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rand-0.8.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand/0.8.5/download"
+              ],
+              "strip_prefix": "rand-0.8.5",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rand-0.8.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rand_chacha-0.3.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
+              ],
+              "strip_prefix": "rand_chacha-0.3.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rand_core-0.6.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_core/0.6.4/download"
+              ],
+              "strip_prefix": "rand_core-0.6.4",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rayon-1.7.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rayon/1.7.0/download"
+              ],
+              "strip_prefix": "rayon-1.7.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rayon-1.7.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rayon-core-1.11.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rayon-core/1.11.0/download"
+              ],
+              "strip_prefix": "rayon-core-1.11.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rayon-core-1.11.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__redox_syscall-0.2.16": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.2.16/download"
+              ],
+              "strip_prefix": "redox_syscall-0.2.16",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.redox_syscall-0.2.16.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__redox_syscall-0.3.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.3.5/download"
+              ],
+              "strip_prefix": "redox_syscall-0.3.5",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.redox_syscall-0.3.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__regex-1.9.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.9.1/download"
+              ],
+              "strip_prefix": "regex-1.9.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.regex-1.9.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__regex-automata-0.1.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.1.10/download"
+              ],
+              "strip_prefix": "regex-automata-0.1.10",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.regex-automata-0.1.10.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__regex-automata-0.3.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.3.3/download"
+              ],
+              "strip_prefix": "regex-automata-0.3.3",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__regex-syntax-0.7.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.7.4/download"
+              ],
+              "strip_prefix": "regex-syntax-0.7.4",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.regex-syntax-0.7.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ring-0.17.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ring/0.17.5/download"
+              ],
+              "strip_prefix": "ring-0.17.5",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ring-0.17.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rouille-3.6.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3716fbf57fc1084d7a706adf4e445298d123e4a44294c4e8213caf1b85fcc921",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rouille/3.6.2/download"
+              ],
+              "strip_prefix": "rouille-3.6.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rouille-3.6.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rustc-demangle-0.1.23": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-demangle/0.1.23/download"
+              ],
+              "strip_prefix": "rustc-demangle-0.1.23",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rustc-demangle-0.1.23.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rustix-0.37.23": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.37.23/download"
+              ],
+              "strip_prefix": "rustix-0.37.23",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rustls-0.21.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustls/0.21.8/download"
+              ],
+              "strip_prefix": "rustls-0.21.8",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rustls-0.21.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rustls-webpki-0.101.7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustls-webpki/0.101.7/download"
+              ],
+              "strip_prefix": "rustls-webpki-0.101.7",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rustls-webpki-0.101.7.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ryu-1.0.14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ryu/1.0.14/download"
+              ],
+              "strip_prefix": "ryu-1.0.14",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__safemem-0.3.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/safemem/0.3.3/download"
+              ],
+              "strip_prefix": "safemem-0.3.3",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.safemem-0.3.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__scopeguard-1.1.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scopeguard/1.1.0/download"
+              ],
+              "strip_prefix": "scopeguard-1.1.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.scopeguard-1.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__sct-0.7.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sct/0.7.1/download"
+              ],
+              "strip_prefix": "sct-0.7.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.sct-0.7.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__semver-1.0.17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/semver/1.0.17/download"
+              ],
+              "strip_prefix": "semver-1.0.17",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.semver-1.0.17.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__serde-1.0.171": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde/1.0.171/download"
+              ],
+              "strip_prefix": "serde-1.0.171",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.serde-1.0.171.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__serde_derive-1.0.171": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_derive/1.0.171/download"
+              ],
+              "strip_prefix": "serde_derive-1.0.171",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.serde_derive-1.0.171.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__serde_json-1.0.102": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_json/1.0.102/download"
+              ],
+              "strip_prefix": "serde_json-1.0.102",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.serde_json-1.0.102.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__sha1_smol-1.0.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sha1_smol/1.0.0/download"
+              ],
+              "strip_prefix": "sha1_smol-1.0.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.sha1_smol-1.0.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__spin-0.9.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/spin/0.9.8/download"
+              ],
+              "strip_prefix": "spin-0.9.8",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.spin-0.9.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__stable_deref_trait-1.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/stable_deref_trait/1.2.0/download"
+              ],
+              "strip_prefix": "stable_deref_trait-1.2.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.stable_deref_trait-1.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__strsim-0.10.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.10.0/download"
+              ],
+              "strip_prefix": "strsim-0.10.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__syn-1.0.109": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/1.0.109/download"
+              ],
+              "strip_prefix": "syn-1.0.109",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.syn-1.0.109.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__syn-2.0.25": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.25/download"
+              ],
+              "strip_prefix": "syn-2.0.25",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.syn-2.0.25.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__tempfile-3.6.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tempfile/3.6.0/download"
+              ],
+              "strip_prefix": "tempfile-3.6.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.tempfile-3.6.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__termcolor-1.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/termcolor/1.2.0/download"
+              ],
+              "strip_prefix": "termcolor-1.2.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.termcolor-1.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__termtree-0.4.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/termtree/0.4.1/download"
+              ],
+              "strip_prefix": "termtree-0.4.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.termtree-0.4.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__threadpool-1.8.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/threadpool/1.8.1/download"
+              ],
+              "strip_prefix": "threadpool-1.8.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.threadpool-1.8.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__time-0.3.23": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/time/0.3.23/download"
+              ],
+              "strip_prefix": "time-0.3.23",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.time-0.3.23.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__time-core-0.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/time-core/0.1.1/download"
+              ],
+              "strip_prefix": "time-core-0.1.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.time-core-0.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__tiny_http-0.12.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tiny_http/0.12.0/download"
+              ],
+              "strip_prefix": "tiny_http-0.12.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.tiny_http-0.12.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__tinyvec-1.6.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tinyvec/1.6.0/download"
+              ],
+              "strip_prefix": "tinyvec-1.6.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.tinyvec-1.6.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__tinyvec_macros-0.1.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tinyvec_macros/0.1.1/download"
+              ],
+              "strip_prefix": "tinyvec_macros-0.1.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.tinyvec_macros-0.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__twoway-0.1.8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/twoway/0.1.8/download"
+              ],
+              "strip_prefix": "twoway-0.1.8",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.twoway-0.1.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicase-2.6.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicase/2.6.0/download"
+              ],
+              "strip_prefix": "unicase-2.6.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicase-2.6.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicode-bidi-0.3.13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-bidi/0.3.13/download"
+              ],
+              "strip_prefix": "unicode-bidi-0.3.13",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicode-bidi-0.3.13.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicode-ident-1.0.10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.10/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.10",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicode-normalization-0.1.22": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-normalization/0.1.22/download"
+              ],
+              "strip_prefix": "unicode-normalization-0.1.22",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicode-normalization-0.1.22.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicode-segmentation-1.10.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-segmentation/1.10.1/download"
+              ],
+              "strip_prefix": "unicode-segmentation-1.10.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicode-segmentation-1.10.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__untrusted-0.9.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/untrusted/0.9.0/download"
+              ],
+              "strip_prefix": "untrusted-0.9.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.untrusted-0.9.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ureq-2.8.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ureq/2.8.0/download"
+              ],
+              "strip_prefix": "ureq-2.8.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ureq-2.8.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__url-2.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/url/2.4.0/download"
+              ],
+              "strip_prefix": "url-2.4.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.url-2.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__version_check-0.9.4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/version_check/0.9.4/download"
+              ],
+              "strip_prefix": "version_check-0.9.4",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.version_check-0.9.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wait-timeout-0.2.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wait-timeout/0.2.0/download"
+              ],
+              "strip_prefix": "wait-timeout-0.2.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wait-timeout-0.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__walrus-0.20.3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2c03529cd0c4400a2449f640d2f27cd1b48c3065226d15e26d98e4429ab0adb7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/walrus/0.20.3/download"
+              ],
+              "strip_prefix": "walrus-0.20.3",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.walrus-0.20.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__walrus-macro-0.19.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/walrus-macro/0.19.0/download"
+              ],
+              "strip_prefix": "walrus-macro-0.19.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.walrus-macro-0.19.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasi-0.11.0-wasi-snapshot-preview1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
+              ],
+              "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-backend-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-backend/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-backend-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-backend-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ca821da8c1ae6c87c5e94493939a206daa8587caff227c6032e0061a3d80817f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-cli-support/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-cli-support-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-cli-support-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-externref-xform-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "102582726b35a30d53157fbf8de3d0f0fed4c40c0c7951d69a034e9ef01da725",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-externref-xform/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-externref-xform-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-externref-xform-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-macro-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-macro/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-macro-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-macro-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-macro-support-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-macro-support-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-macro-support-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-multi-value-xform-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3498e4799f43523d780ceff498f04d882a8dbc9719c28020034822e5952f32a4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-multi-value-xform/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-multi-value-xform-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-multi-value-xform-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-shared/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-shared-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-shared-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-threads-xform-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "2d5add359b7f7d09a55299a9d29be54414264f2b8cf84f8c8fda5be9269b5dd9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-threads-xform/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-threads-xform-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-threads-xform-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-wasm-conventions-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "8c04e3607b810e76768260db3a5f2e8beb477cb089ef8726da85c8eb9bd3b575",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-wasm-conventions/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-wasm-conventions-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-conventions-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-wasm-interpreter-0.2.92": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9ea966593c8243a33eb4d643254eb97a69de04e89462f46cf6b4f506aae89b3a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-wasm-interpreter/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-wasm-interpreter-0.2.92",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-interpreter-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-encoder-0.29.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-encoder/0.29.0/download"
+              ],
+              "strip_prefix": "wasm-encoder-0.29.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-encoder-0.29.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasmparser-0.102.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasmparser/0.102.0/download"
+              ],
+              "strip_prefix": "wasmparser-0.102.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.102.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasmparser-0.108.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "76c956109dcb41436a39391139d9b6e2d0a5e0b158e1293ef352ec977e5e36c5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasmparser/0.108.0/download"
+              ],
+              "strip_prefix": "wasmparser-0.108.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.108.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasmparser-0.80.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "449167e2832691a1bff24cde28d2804e90e09586a448c8e76984792c44334a6b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasmparser/0.80.2/download"
+              ],
+              "strip_prefix": "wasmparser-0.80.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.80.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasmprinter-0.2.60": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b76cb909fe3d9b0de58cee1f4072247e680ff5cc1558ccad2790a9de14a23993",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasmprinter/0.2.60/download"
+              ],
+              "strip_prefix": "wasmprinter-0.2.60",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasmprinter-0.2.60.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__webpki-roots-0.25.2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/webpki-roots/0.25.2/download"
+              ],
+              "strip_prefix": "webpki-roots-0.25.2",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.webpki-roots-0.25.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__winapi-0.3.9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__winapi-i686-pc-windows-gnu-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__winapi-util-0.1.5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-util/0.1.5/download"
+              ],
+              "strip_prefix": "winapi-util-0.1.5",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows/0.48.0/download"
+              ],
+              "strip_prefix": "windows-0.48.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows-sys-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.48.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.48.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows-targets-0.48.1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.48.1/download"
+              ],
+              "strip_prefix": "windows-targets-0.48.1",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_aarch64_gnullvm-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_aarch64_msvc-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.48.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_i686_gnu-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.48.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_i686_msvc-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.48.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_x86_64_gnu-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.48.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_x86_64_gnullvm-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_x86_64_msvc-0.48.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.48.0",
+              "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
+            }
+          },
+          "rules_rust_test_load_arbitrary_tool": {
+            "bzlFile": "@@rules_rust~//test/load_arbitrary_tool:load_arbitrary_tool_test.bzl",
+            "ruleClassName": "_load_arbitrary_tool_test",
+            "attributes": {}
+          },
+          "generated_inputs_in_external_repo": {
+            "bzlFile": "@@rules_rust~//test/generated_inputs:external_repo.bzl",
+            "ruleClassName": "_generated_inputs_in_external_repo",
+            "attributes": {}
+          },
+          "libc": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file_content": "load(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\nrust_library(\n    name = \"libc\",\n    srcs = glob([\"src/**/*.rs\"]),\n    edition = \"2015\",\n    rustc_flags = [\n        # In most cases, warnings in 3rd party crates are not interesting as\n        # they're out of the control of consumers. The flag here silences\n        # warnings. For more details see:\n        # https://doc.rust-lang.org/rustc/lints/levels.html\n        \"--cap-lints=allow\",\n    ],\n    visibility = [\"//visibility:public\"],\n)\n",
+              "sha256": "1ac4c2ac6ed5a8fb9020c166bc63316205f1dc78d4b964ad31f4f21eb73f0c6d",
+              "strip_prefix": "libc-0.2.20",
+              "urls": [
+                "https://mirror.bazel.build/github.com/rust-lang/libc/archive/0.2.20.zip",
+                "https://github.com/rust-lang/libc/archive/0.2.20.zip"
+              ]
+            }
+          },
+          "rules_rust_toolchain_test_target_json": {
+            "bzlFile": "@@rules_rust~//test/unit/toolchain:toolchain_test_utils.bzl",
+            "ruleClassName": "rules_rust_toolchain_test_target_json_repository",
+            "attributes": {
+              "target_json": "@@rules_rust~//test/unit/toolchain:toolchain-test-triple.json"
+            }
+          },
+          "com_google_googleapis": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/googleapis/googleapis/archive/18becb1d1426feb7399db144d7beeb3284f1ccb0.zip"
+              ],
+              "strip_prefix": "googleapis-18becb1d1426feb7399db144d7beeb3284f1ccb0",
+              "sha256": "b8c487191eb942361af905e40172644eab490190e717c3d09bf83e87f3994fff"
+            }
+          },
+          "rules_python": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "778aaeab3e6cfd56d681c89f5c10d7ad6bf8d2f1a72de9de55b23081b2d31618",
+              "strip_prefix": "rules_python-0.34.0",
+              "url": "https://github.com/bazelbuild/rules_python/releases/download/0.34.0/rules_python-0.34.0.tar.gz"
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [
+            "rules_rust_tinyjson",
+            "cui",
+            "cui__anyhow-1.0.75",
+            "cui__camino-1.1.6",
+            "cui__cargo-lock-9.0.0",
+            "cui__cargo-platform-0.1.4",
+            "cui__cargo_metadata-0.18.1",
+            "cui__cargo_toml-0.19.2",
+            "cui__cfg-expr-0.15.5",
+            "cui__clap-4.3.11",
+            "cui__crates-index-2.2.0",
+            "cui__hex-0.4.3",
+            "cui__indoc-2.0.4",
+            "cui__itertools-0.12.0",
+            "cui__normpath-1.1.1",
+            "cui__once_cell-1.19.0",
+            "cui__pathdiff-0.2.1",
+            "cui__regex-1.10.2",
+            "cui__semver-1.0.20",
+            "cui__serde-1.0.190",
+            "cui__serde_json-1.0.108",
+            "cui__serde_starlark-0.1.14",
+            "cui__sha2-0.10.8",
+            "cui__spdx-0.10.3",
+            "cui__tempfile-3.8.1",
+            "cui__tera-1.19.1",
+            "cui__textwrap-0.16.0",
+            "cui__toml-0.8.10",
+            "cui__tracing-0.1.40",
+            "cui__tracing-subscriber-0.3.17",
+            "cui__url-2.5.2",
+            "cui__maplit-1.0.2",
+            "cui__spectral-0.6.0",
+            "cargo_bazel.buildifier-darwin-amd64",
+            "cargo_bazel.buildifier-darwin-arm64",
+            "cargo_bazel.buildifier-linux-amd64",
+            "cargo_bazel.buildifier-linux-arm64",
+            "cargo_bazel.buildifier-linux-s390x",
+            "cargo_bazel.buildifier-windows-amd64.exe",
+            "rules_rust_prost__heck",
+            "rules_rust_prost",
+            "rules_rust_prost__h2-0.4.6",
+            "rules_rust_prost__prost-0.13.1",
+            "rules_rust_prost__prost-types-0.13.1",
+            "rules_rust_prost__protoc-gen-prost-0.4.0",
+            "rules_rust_prost__protoc-gen-tonic-0.4.1",
+            "rules_rust_prost__tokio-1.39.3",
+            "rules_rust_prost__tokio-stream-0.1.15",
+            "rules_rust_prost__tonic-0.12.1",
+            "rules_rust_proto__grpc-0.6.2",
+            "rules_rust_proto__grpc-compiler-0.6.2",
+            "rules_rust_proto__log-0.4.17",
+            "rules_rust_proto__protobuf-2.8.2",
+            "rules_rust_proto__protobuf-codegen-2.8.2",
+            "rules_rust_proto__tls-api-0.1.22",
+            "rules_rust_proto__tls-api-stub-0.1.22",
+            "llvm-raw",
+            "rules_rust_bindgen__bindgen-cli-0.70.1",
+            "rules_rust_bindgen__bindgen-0.70.1",
+            "rules_rust_bindgen__clang-sys-1.8.1",
+            "rules_rust_bindgen__clap-4.5.17",
+            "rules_rust_bindgen__clap_complete-4.5.26",
+            "rules_rust_bindgen__env_logger-0.10.2",
+            "rrra__anyhow-1.0.71",
+            "rrra__clap-4.3.11",
+            "rrra__env_logger-0.10.0",
+            "rrra__itertools-0.11.0",
+            "rrra__log-0.4.19",
+            "rrra__serde-1.0.171",
+            "rrra__serde_json-1.0.102",
+            "rules_rust_wasm_bindgen_cli",
+            "rules_rust_wasm_bindgen__anyhow-1.0.71",
+            "rules_rust_wasm_bindgen__docopt-1.1.1",
+            "rules_rust_wasm_bindgen__env_logger-0.8.4",
+            "rules_rust_wasm_bindgen__log-0.4.19",
+            "rules_rust_wasm_bindgen__rouille-3.6.2",
+            "rules_rust_wasm_bindgen__serde-1.0.171",
+            "rules_rust_wasm_bindgen__serde_derive-1.0.171",
+            "rules_rust_wasm_bindgen__serde_json-1.0.102",
+            "rules_rust_wasm_bindgen__ureq-2.8.0",
+            "rules_rust_wasm_bindgen__walrus-0.20.3",
+            "rules_rust_wasm_bindgen__wasm-bindgen-0.2.92",
+            "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92",
+            "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92",
+            "rules_rust_wasm_bindgen__assert_cmd-1.0.8",
+            "rules_rust_wasm_bindgen__diff-0.1.13",
+            "rules_rust_wasm_bindgen__predicates-1.0.8",
+            "rules_rust_wasm_bindgen__rayon-1.7.0",
+            "rules_rust_wasm_bindgen__tempfile-3.6.0",
+            "rules_rust_wasm_bindgen__wasmparser-0.102.0",
+            "rules_rust_wasm_bindgen__wasmprinter-0.2.60",
+            "rules_rust_test_load_arbitrary_tool",
+            "generated_inputs_in_external_repo",
+            "libc",
+            "rules_rust_toolchain_test_target_json",
+            "com_google_googleapis",
+            "rules_python"
+          ],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO",
+          "reproducible": false
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_rust~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "rules_rust~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_rust~",
+            "cui__anyhow-1.0.75",
+            "rules_rust~~i~cui__anyhow-1.0.75"
+          ],
+          [
+            "rules_rust~",
+            "cui__camino-1.1.6",
+            "rules_rust~~i~cui__camino-1.1.6"
+          ],
+          [
+            "rules_rust~",
+            "cui__cargo-lock-9.0.0",
+            "rules_rust~~i~cui__cargo-lock-9.0.0"
+          ],
+          [
+            "rules_rust~",
+            "cui__cargo-platform-0.1.4",
+            "rules_rust~~i~cui__cargo-platform-0.1.4"
+          ],
+          [
+            "rules_rust~",
+            "cui__cargo_metadata-0.18.1",
+            "rules_rust~~i~cui__cargo_metadata-0.18.1"
+          ],
+          [
+            "rules_rust~",
+            "cui__cargo_toml-0.19.2",
+            "rules_rust~~i~cui__cargo_toml-0.19.2"
+          ],
+          [
+            "rules_rust~",
+            "cui__cfg-expr-0.15.5",
+            "rules_rust~~i~cui__cfg-expr-0.15.5"
+          ],
+          [
+            "rules_rust~",
+            "cui__clap-4.3.11",
+            "rules_rust~~i~cui__clap-4.3.11"
+          ],
+          [
+            "rules_rust~",
+            "cui__crates-index-2.2.0",
+            "rules_rust~~i~cui__crates-index-2.2.0"
+          ],
+          [
+            "rules_rust~",
+            "cui__hex-0.4.3",
+            "rules_rust~~i~cui__hex-0.4.3"
+          ],
+          [
+            "rules_rust~",
+            "cui__indoc-2.0.4",
+            "rules_rust~~i~cui__indoc-2.0.4"
+          ],
+          [
+            "rules_rust~",
+            "cui__itertools-0.12.0",
+            "rules_rust~~i~cui__itertools-0.12.0"
+          ],
+          [
+            "rules_rust~",
+            "cui__maplit-1.0.2",
+            "rules_rust~~i~cui__maplit-1.0.2"
+          ],
+          [
+            "rules_rust~",
+            "cui__normpath-1.1.1",
+            "rules_rust~~i~cui__normpath-1.1.1"
+          ],
+          [
+            "rules_rust~",
+            "cui__once_cell-1.19.0",
+            "rules_rust~~i~cui__once_cell-1.19.0"
+          ],
+          [
+            "rules_rust~",
+            "cui__pathdiff-0.2.1",
+            "rules_rust~~i~cui__pathdiff-0.2.1"
+          ],
+          [
+            "rules_rust~",
+            "cui__regex-1.10.2",
+            "rules_rust~~i~cui__regex-1.10.2"
+          ],
+          [
+            "rules_rust~",
+            "cui__semver-1.0.20",
+            "rules_rust~~i~cui__semver-1.0.20"
+          ],
+          [
+            "rules_rust~",
+            "cui__serde-1.0.190",
+            "rules_rust~~i~cui__serde-1.0.190"
+          ],
+          [
+            "rules_rust~",
+            "cui__serde_json-1.0.108",
+            "rules_rust~~i~cui__serde_json-1.0.108"
+          ],
+          [
+            "rules_rust~",
+            "cui__serde_starlark-0.1.14",
+            "rules_rust~~i~cui__serde_starlark-0.1.14"
+          ],
+          [
+            "rules_rust~",
+            "cui__sha2-0.10.8",
+            "rules_rust~~i~cui__sha2-0.10.8"
+          ],
+          [
+            "rules_rust~",
+            "cui__spdx-0.10.3",
+            "rules_rust~~i~cui__spdx-0.10.3"
+          ],
+          [
+            "rules_rust~",
+            "cui__spectral-0.6.0",
+            "rules_rust~~i~cui__spectral-0.6.0"
+          ],
+          [
+            "rules_rust~",
+            "cui__tempfile-3.8.1",
+            "rules_rust~~i~cui__tempfile-3.8.1"
+          ],
+          [
+            "rules_rust~",
+            "cui__tera-1.19.1",
+            "rules_rust~~i~cui__tera-1.19.1"
+          ],
+          [
+            "rules_rust~",
+            "cui__textwrap-0.16.0",
+            "rules_rust~~i~cui__textwrap-0.16.0"
+          ],
+          [
+            "rules_rust~",
+            "cui__toml-0.8.10",
+            "rules_rust~~i~cui__toml-0.8.10"
+          ],
+          [
+            "rules_rust~",
+            "cui__tracing-0.1.40",
+            "rules_rust~~i~cui__tracing-0.1.40"
+          ],
+          [
+            "rules_rust~",
+            "cui__tracing-subscriber-0.3.17",
+            "rules_rust~~i~cui__tracing-subscriber-0.3.17"
+          ],
+          [
+            "rules_rust~",
+            "cui__url-2.5.2",
+            "rules_rust~~i~cui__url-2.5.2"
+          ],
+          [
+            "rules_rust~",
+            "rrra__anyhow-1.0.71",
+            "rules_rust~~i~rrra__anyhow-1.0.71"
+          ],
+          [
+            "rules_rust~",
+            "rrra__clap-4.3.11",
+            "rules_rust~~i~rrra__clap-4.3.11"
+          ],
+          [
+            "rules_rust~",
+            "rrra__env_logger-0.10.0",
+            "rules_rust~~i~rrra__env_logger-0.10.0"
+          ],
+          [
+            "rules_rust~",
+            "rrra__itertools-0.11.0",
+            "rules_rust~~i~rrra__itertools-0.11.0"
+          ],
+          [
+            "rules_rust~",
+            "rrra__log-0.4.19",
+            "rules_rust~~i~rrra__log-0.4.19"
+          ],
+          [
+            "rules_rust~",
+            "rrra__serde-1.0.171",
+            "rules_rust~~i~rrra__serde-1.0.171"
+          ],
+          [
+            "rules_rust~",
+            "rrra__serde_json-1.0.102",
+            "rules_rust~~i~rrra__serde_json-1.0.102"
+          ],
+          [
+            "rules_rust~",
+            "rules_cc",
+            "rules_cc~"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust",
+            "rules_rust~"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_bindgen__bindgen-0.70.1",
+            "rules_rust~~i~rules_rust_bindgen__bindgen-0.70.1"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_bindgen__clang-sys-1.8.1",
+            "rules_rust~~i~rules_rust_bindgen__clang-sys-1.8.1"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_bindgen__clap-4.5.17",
+            "rules_rust~~i~rules_rust_bindgen__clap-4.5.17"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_bindgen__clap_complete-4.5.26",
+            "rules_rust~~i~rules_rust_bindgen__clap_complete-4.5.26"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_bindgen__env_logger-0.10.2",
+            "rules_rust~~i~rules_rust_bindgen__env_logger-0.10.2"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_prost__h2-0.4.6",
+            "rules_rust~~i~rules_rust_prost__h2-0.4.6"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_prost__prost-0.13.1",
+            "rules_rust~~i~rules_rust_prost__prost-0.13.1"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_prost__prost-types-0.13.1",
+            "rules_rust~~i~rules_rust_prost__prost-types-0.13.1"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_prost__protoc-gen-prost-0.4.0",
+            "rules_rust~~i~rules_rust_prost__protoc-gen-prost-0.4.0"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_prost__protoc-gen-tonic-0.4.1",
+            "rules_rust~~i~rules_rust_prost__protoc-gen-tonic-0.4.1"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_prost__tokio-1.39.3",
+            "rules_rust~~i~rules_rust_prost__tokio-1.39.3"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_prost__tokio-stream-0.1.15",
+            "rules_rust~~i~rules_rust_prost__tokio-stream-0.1.15"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_prost__tonic-0.12.1",
+            "rules_rust~~i~rules_rust_prost__tonic-0.12.1"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_proto__grpc-0.6.2",
+            "rules_rust~~i~rules_rust_proto__grpc-0.6.2"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_proto__grpc-compiler-0.6.2",
+            "rules_rust~~i~rules_rust_proto__grpc-compiler-0.6.2"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_proto__log-0.4.17",
+            "rules_rust~~i~rules_rust_proto__log-0.4.17"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_proto__protobuf-2.8.2",
+            "rules_rust~~i~rules_rust_proto__protobuf-2.8.2"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_proto__protobuf-codegen-2.8.2",
+            "rules_rust~~i~rules_rust_proto__protobuf-codegen-2.8.2"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_proto__tls-api-0.1.22",
+            "rules_rust~~i~rules_rust_proto__tls-api-0.1.22"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_proto__tls-api-stub-0.1.22",
+            "rules_rust~~i~rules_rust_proto__tls-api-stub-0.1.22"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__anyhow-1.0.71",
+            "rules_rust~~i~rules_rust_wasm_bindgen__anyhow-1.0.71"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__assert_cmd-1.0.8",
+            "rules_rust~~i~rules_rust_wasm_bindgen__assert_cmd-1.0.8"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__diff-0.1.13",
+            "rules_rust~~i~rules_rust_wasm_bindgen__diff-0.1.13"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__docopt-1.1.1",
+            "rules_rust~~i~rules_rust_wasm_bindgen__docopt-1.1.1"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__env_logger-0.8.4",
+            "rules_rust~~i~rules_rust_wasm_bindgen__env_logger-0.8.4"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__log-0.4.19",
+            "rules_rust~~i~rules_rust_wasm_bindgen__log-0.4.19"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__predicates-1.0.8",
+            "rules_rust~~i~rules_rust_wasm_bindgen__predicates-1.0.8"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__rayon-1.7.0",
+            "rules_rust~~i~rules_rust_wasm_bindgen__rayon-1.7.0"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__rouille-3.6.2",
+            "rules_rust~~i~rules_rust_wasm_bindgen__rouille-3.6.2"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__serde-1.0.171",
+            "rules_rust~~i~rules_rust_wasm_bindgen__serde-1.0.171"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__serde_derive-1.0.171",
+            "rules_rust~~i~rules_rust_wasm_bindgen__serde_derive-1.0.171"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__serde_json-1.0.102",
+            "rules_rust~~i~rules_rust_wasm_bindgen__serde_json-1.0.102"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__tempfile-3.6.0",
+            "rules_rust~~i~rules_rust_wasm_bindgen__tempfile-3.6.0"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__ureq-2.8.0",
+            "rules_rust~~i~rules_rust_wasm_bindgen__ureq-2.8.0"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__walrus-0.20.3",
+            "rules_rust~~i~rules_rust_wasm_bindgen__walrus-0.20.3"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__wasm-bindgen-0.2.92",
+            "rules_rust~~i~rules_rust_wasm_bindgen__wasm-bindgen-0.2.92"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92",
+            "rules_rust~~i~rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92",
+            "rules_rust~~i~rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__wasmparser-0.102.0",
+            "rules_rust~~i~rules_rust_wasm_bindgen__wasmparser-0.102.0"
+          ],
+          [
+            "rules_rust~",
+            "rules_rust_wasm_bindgen__wasmprinter-0.2.60",
+            "rules_rust~~i~rules_rust_wasm_bindgen__wasmprinter-0.2.60"
+          ]
+        ]
+      }
+    },
+    "@@rules_swift~//swift:extensions.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "9v7oV8oD+hvRLQU5WxJYafojNgO5Lk1/rVg3aTb5vHk=",
+        "usagesDigest": "/dVEtCLqIAaLXjfRXsJupTS9pTgmYVN/tFdJlGgE5NA=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_apple_swift_protobuf": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-protobuf/archive/1.20.2.tar.gz"
+              ],
+              "sha256": "3fb50bd4d293337f202d917b6ada22f9548a0a0aed9d9a4d791e6fbd8a246ebb",
+              "strip_prefix": "swift-protobuf-1.20.2/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_protobuf/BUILD.overlay"
+            }
+          },
+          "com_github_grpc_grpc_swift": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/grpc/grpc-swift/archive/1.16.0.tar.gz"
+              ],
+              "sha256": "58b60431d0064969f9679411264b82e40a217ae6bd34e17096d92cc4e47556a5",
+              "strip_prefix": "grpc-swift-1.16.0/",
+              "build_file": "@@rules_swift~//third_party:com_github_grpc_grpc_swift/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_docc_symbolkit": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-docc-symbolkit/archive/refs/tags/swift-5.10-RELEASE.tar.gz"
+              ],
+              "sha256": "de1d4b6940468ddb53b89df7aa1a81323b9712775b0e33e8254fa0f6f7469a97",
+              "strip_prefix": "swift-docc-symbolkit-swift-5.10-RELEASE",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_docc_symbolkit/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio/archive/2.42.0.tar.gz"
+              ],
+              "sha256": "e3304bc3fb53aea74a3e54bd005ede11f6dc357117d9b1db642d03aea87194a0",
+              "strip_prefix": "swift-nio-2.42.0/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_nio/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_http2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-http2/archive/1.26.0.tar.gz"
+              ],
+              "sha256": "f0edfc9d6a7be1d587e5b403f2d04264bdfae59aac1d74f7d974a9022c6d2b25",
+              "strip_prefix": "swift-nio-http2-1.26.0/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_nio_http2/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_transport_services": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-transport-services/archive/1.15.0.tar.gz"
+              ],
+              "sha256": "f3498dafa633751a52b9b7f741f7ac30c42bcbeb3b9edca6d447e0da8e693262",
+              "strip_prefix": "swift-nio-transport-services-1.15.0/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_extras": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-extras/archive/1.4.0.tar.gz"
+              ],
+              "sha256": "4684b52951d9d9937bb3e8ccd6b5daedd777021ef2519ea2f18c4c922843b52b",
+              "strip_prefix": "swift-nio-extras-1.4.0/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_nio_extras/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_log": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-log/archive/1.4.4.tar.gz"
+              ],
+              "sha256": "48fe66426c784c0c20031f15dc17faf9f4c9037c192bfac2f643f65cb2321ba0",
+              "strip_prefix": "swift-log-1.4.4/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_log/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_ssl": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-ssl/archive/2.23.0.tar.gz"
+              ],
+              "sha256": "4787c63f61dd04d99e498adc3d1a628193387e41efddf8de19b8db04544d016d",
+              "strip_prefix": "swift-nio-ssl-2.23.0/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_nio_ssl/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_collections": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-collections/archive/1.0.4.tar.gz"
+              ],
+              "sha256": "d9e4c8a91c60fb9c92a04caccbb10ded42f4cb47b26a212bc6b39cc390a4b096",
+              "strip_prefix": "swift-collections-1.0.4/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_collections/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_atomics": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-atomics/archive/1.1.0.tar.gz"
+              ],
+              "sha256": "1bee7f469f7e8dc49f11cfa4da07182fbc79eab000ec2c17bfdce468c5d276fb",
+              "strip_prefix": "swift-atomics-1.1.0/",
+              "build_file": "@@rules_swift~//third_party:com_github_apple_swift_atomics/BUILD.overlay"
+            }
+          },
+          "build_bazel_rules_swift_index_import": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@rules_swift~//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
+              "canonical_id": "index-import-5.8",
+              "urls": [
+                "https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"
+              ],
+              "sha256": "28c1ffa39d99e74ed70623899b207b41f79214c498c603915aef55972a851a15"
+            }
+          },
+          "build_bazel_rules_swift_local_config": {
+            "bzlFile": "@@rules_swift~//swift/internal:swift_autoconfiguration.bzl",
+            "ruleClassName": "swift_autoconfiguration",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_swift~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_swift~",
+            "build_bazel_rules_swift",
+            "rules_swift~"
           ]
         ]
       }

--- a/d/BUILD.bazel
+++ b/d/BUILD.bazel
@@ -25,6 +25,7 @@ bzl_library(
     deps = [
         "//d/private/rules:binary",
         "//d/private/rules:library",
+        "//d/private/rules:proto",
         "//d/private/rules:test",
     ],
 )

--- a/d/defs.bzl
+++ b/d/defs.bzl
@@ -2,8 +2,10 @@
 
 load("//d/private/rules:binary.bzl", _d_binary = "d_binary")
 load("//d/private/rules:library.bzl", _d_library = "d_library")
+load("//d/private/rules:proto.bzl", _d_proto_library = "d_proto_library")
 load("//d/private/rules:test.bzl", _d_test = "d_test")
 
 d_binary = _d_binary
 d_library = _d_library
+d_proto_library = _d_proto_library
 d_test = _d_test

--- a/d/extensions.bzl
+++ b/d/extensions.bzl
@@ -10,7 +10,7 @@ names (the latest version will be picked for each name) and can register them as
 effectively overriding the default named toolchain due to toolchain resolution precedence.
 """
 
-load(":repositories.bzl", "d_register_toolchains", "select_compiler_by_os")
+load(":repositories.bzl", "d_register_toolchains", "protobuf_d_dependencies", "select_compiler_by_os")
 
 _DEFAULT_NAME = "d"
 
@@ -64,4 +64,11 @@ d = module_extension(
     # regardless of the host platform.
     os_dependent = False,
     arch_dependent = False,
+)
+
+def _protobuf_d_extension(_module_ctx):
+    protobuf_d_dependencies()
+
+protobuf_d = module_extension(
+    implementation = _protobuf_d_extension,
 )

--- a/d/private/rules/BUILD.bazel
+++ b/d/private/rules/BUILD.bazel
@@ -45,6 +45,7 @@ bzl_library(
         "//d/private/rules:utils",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
+        "@rules_cc//cc:defs_bzl",
     ],
 )
 
@@ -57,6 +58,22 @@ bzl_library(
     ],
     deps = [
         "//d/private/rules:compile",
+    ],
+)
+
+bzl_library(
+    name = "proto",
+    srcs = ["proto.bzl"],
+    visibility = [
+        "//d:__subpackages__",
+        "//docs:__subpackages__",
+    ],
+    deps = [
+        "//d/private:providers",
+        "//d/private/rules:compile",
+        "@bazel_skylib//lib:paths",
+        "@protobuf//bazel/common:proto_info_bzl",
+        "@rules_cc//cc:defs_bzl",
     ],
 )
 

--- a/d/private/rules/binary.bzl
+++ b/d/private/rules/binary.bzl
@@ -1,13 +1,32 @@
 """D test rule for compiling binaries."""
 
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_variables")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "use_cc_toolchain")
 load("//d/private/rules:compile.bzl", "TARGET_TYPE", "d_compile", "runnable_attrs")
 load("//d/private/rules:link.bzl", "link_action")
+load("//d/private/rules:utils.bzl", "object_file_name")
 
 def _d_binary_impl(ctx):
     """Implementation of d_binary rule."""
-    d_info = d_compile(ctx, target_type = TARGET_TYPE.BINARY)
+    d_info = d_compile(
+        actions = ctx.actions,
+        label = ctx.label,
+        toolchain = ctx.toolchains["//d:toolchain_type"].d_toolchain_info,
+        compilation_mode = ctx.var["COMPILATION_MODE"],
+        env = ctx.var,
+        srcs = ctx.files.srcs,
+        deps = ctx.attr.deps,
+        dopts = ctx.attr.dopts,
+        imports = [paths.join(ctx.label.workspace_root, ctx.label.package, imp) for imp in ctx.attr.imports],
+        linkopts = ctx.attr.linkopts,
+        string_srcs = ctx.files.string_srcs,
+        string_imports = ([paths.join(ctx.label.workspace_root, ctx.label.package)] if ctx.files.string_srcs else []) +
+                         [paths.join(ctx.label.workspace_root, ctx.label.package, imp) for imp in ctx.attr.string_imports],
+        versions = ctx.attr.versions,
+        output = ctx.actions.declare_file(object_file_name(ctx, ctx.label.name)),
+        target_type = TARGET_TYPE.BINARY,
+    )
     output = link_action(ctx, d_info)
     env_with_expansions = {
         k: expand_variables(ctx, ctx.expand_location(v, ctx.attr.data), [output], "env")

--- a/d/private/rules/binary.bzl
+++ b/d/private/rules/binary.bzl
@@ -2,12 +2,12 @@
 
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_variables")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "use_cc_toolchain")
-load("//d/private/rules:compile.bzl", "TARGET_TYPE", "compilation_action", "runnable_attrs")
+load("//d/private/rules:compile.bzl", "TARGET_TYPE", "d_compile", "runnable_attrs")
 load("//d/private/rules:link.bzl", "link_action")
 
 def _d_binary_impl(ctx):
     """Implementation of d_binary rule."""
-    d_info = compilation_action(ctx, target_type = TARGET_TYPE.BINARY)
+    d_info = d_compile(ctx, target_type = TARGET_TYPE.BINARY)
     output = link_action(ctx, d_info)
     env_with_expansions = {
         k: expand_variables(ctx, ctx.expand_location(v, ctx.attr.data), [output], "env")

--- a/d/private/rules/compile.bzl
+++ b/d/private/rules/compile.bzl
@@ -5,7 +5,6 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc:defs.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//d/private:providers.bzl", "DInfo")
-load("//d/private/rules:utils.bzl", "object_file_name", "static_library_name")
 
 D_FILE_EXTENSIONS = [".d", ".di"]
 
@@ -58,79 +57,105 @@ TARGET_TYPE = struct(
     TEST = "test",
 )
 
-def d_compile(ctx, target_type = TARGET_TYPE.LIBRARY):
+def d_compile(
+        actions,
+        label,
+        toolchain,
+        compilation_mode,
+        env,
+        srcs,
+        deps,
+        dopts,
+        imports,
+        linkopts,
+        string_srcs,
+        string_imports,
+        versions,
+        output,
+        target_type = TARGET_TYPE.LIBRARY,
+        source_only = False):
     """Defines a compilation action for D source files.
 
     Args:
-        ctx: The rule context.
+        actions: The action factory used to register compile actions.
+        label: The label of the target being compiled.
+        toolchain: The D toolchain provider.
+        compilation_mode: The Bazel compilation mode.
+        env: Environment variables for the compile action.
+        srcs: D source files to compile.
+        deps: Dependency targets providing CcInfo or DInfo.
+        dopts: Compiler flags.
+        imports: Import paths.
+        linkopts: Linker flags passed via -L flags.
+        string_srcs: String import source files.
+        string_imports: String import paths.
+        versions: Version identifiers.
+        output: The output file to produce.
         target_type: The type of the target, either 'binary', 'library', or 'test'.
+        source_only: If true, compile sources without producing a linkable library.
     Returns:
         The DInfo provider containing the compilation information.
     """
-    toolchain = ctx.toolchains["//d:toolchain_type"].d_toolchain_info
-    c_deps = [d[CcInfo] for d in ctx.attr.deps if CcInfo in d]
-    d_deps = [d[DInfo] for d in ctx.attr.deps if DInfo in d]
+    c_deps = [d[CcInfo] for d in deps if CcInfo in d]
+    d_deps = [d[DInfo] for d in deps if DInfo in d]
     compiler_flags = depset(
-        ctx.attr.dopts,
+        dopts,
         transitive = [d.compiler_flags for d in d_deps],
     )
+    direct_imports = imports if imports else [paths.join(label.workspace_root, label.package)]
     imports = depset(
-        [paths.join(ctx.label.workspace_root, ctx.label.package, imp) for imp in ctx.attr.imports],
+        direct_imports,
         transitive = [d.imports for d in d_deps],
     )
     linker_flags = depset(
-        ctx.attr.linkopts,
+        linkopts,
         transitive = [d.linker_flags for d in d_deps],
     )
     string_imports = depset(
-        ([paths.join(ctx.label.workspace_root, ctx.label.package)] if ctx.files.string_srcs else []) +
-        [paths.join(ctx.label.workspace_root, ctx.label.package, imp) for imp in ctx.attr.string_imports],
+        string_imports,
         transitive = [d.string_imports for d in d_deps],
     )
-    versions = depset(ctx.attr.versions, transitive = [d.versions for d in d_deps])
-    args = ctx.actions.args()
-    args.add_all(COMPILATION_MODE_FLAGS[ctx.var["COMPILATION_MODE"]])
-    args.add_all(ctx.files.srcs)
+    versions = depset(versions, transitive = [d.versions for d in d_deps])
+    args = actions.args()
+    args.add_all(COMPILATION_MODE_FLAGS[compilation_mode])
+    args.add_all(srcs)
     args.add_all([i for i in imports.to_list() if i], format_each = "-I=%s")
     args.add_all([si for si in string_imports.to_list() if si], format_each = "-J=%s")
     args.add_all(toolchain.compiler_flags)
     args.add_all(compiler_flags.to_list())
     args.add_all([v for v in versions.to_list() if v], format_each = "-version=%s")
-    output = None
     if target_type == TARGET_TYPE.TEST:
         args.add_all(["-main", "-unittest"])
     if target_type == TARGET_TYPE.LIBRARY:
         args.add("-lib")
-        output = ctx.actions.declare_file(static_library_name(ctx, ctx.label.name))
-        library_to_link = None if ctx.attr.source_only else cc_common.create_library_to_link(
-            actions = ctx.actions,
+        library_to_link = None if source_only else cc_common.create_library_to_link(
+            actions = actions,
             static_library = output,
         )
     else:
         args.add("-c")
-        output = ctx.actions.declare_file(object_file_name(ctx, ctx.label.name))
         library_to_link = None
     args.add(output, format = "-of=%s")
 
     inputs = depset(
-        direct = ctx.files.srcs + ctx.files.string_srcs,
+        direct = srcs + string_srcs,
         transitive = [toolchain.d_compiler[DefaultInfo].default_runfiles.files] +
                      [d.interface_srcs for d in d_deps],
     )
 
-    ctx.actions.run(
+    actions.run(
         inputs = inputs,
         outputs = [output],
         executable = toolchain.d_compiler[DefaultInfo].files_to_run,
         arguments = [args],
-        env = ctx.var,
+        env = env,
         use_default_shell_env = False,
         mnemonic = "Dcompile",
-        progress_message = "Compiling D %s %s" % (target_type, ctx.label.name),
+        progress_message = "Compiling D %s %s" % (target_type, label.name),
         toolchain = "@rules_d//d:toolchain_type",
     )
     linker_input = cc_common.create_linker_input(
-        owner = ctx.label,
+        owner = label,
         libraries = depset(direct = [library_to_link] if library_to_link else None),
     )
     linking_context = cc_common.create_linking_context(
@@ -146,98 +171,18 @@ def d_compile(ctx, target_type = TARGET_TYPE.LIBRARY):
         compilation_output = output,
         compiler_flags = compiler_flags,
         imports = depset(
-            [paths.join(ctx.label.workspace_root, ctx.label.package, imp) for imp in ctx.attr.imports] if ctx.attr.imports else [paths.join(ctx.label.workspace_root, ctx.label.package)],
+            direct_imports,
             transitive = [d.imports for d in d_deps],
         ),
         interface_srcs = depset(
-            ctx.files.srcs + ctx.files.string_srcs,
+            srcs + string_srcs,
             transitive = [d.interface_srcs for d in d_deps],
         ),
         linking_context = linking_context,
         linker_flags = linker_flags,
         string_imports = depset(
-            ([paths.join(ctx.label.workspace_root, ctx.label.package)] if ctx.files.string_srcs else []) +
-            [paths.join(ctx.label.workspace_root, ctx.label.package, imp) for imp in ctx.attr.string_imports],
+            string_imports.to_list(),
             transitive = [d.string_imports for d in d_deps],
         ),
-        versions = versions,
-    )
-
-def d_proto_compile(ctx, srcs, deps, import_root):
-    """Compiles generated D proto sources into a D library.
-
-    Args:
-        ctx: The aspect context.
-        srcs: Generated D source files to compile.
-        deps: Dependency targets providing CcInfo or DInfo.
-        import_root: Import path containing the generated D sources.
-    Returns:
-        The DInfo provider containing the compilation information.
-    """
-    toolchain = ctx.toolchains["//d:toolchain_type"].d_toolchain_info
-    c_deps = [d[CcInfo] for d in deps if CcInfo in d]
-    d_deps = [d[DInfo] for d in deps if DInfo in d]
-    compiler_flags = depset(transitive = [d.compiler_flags for d in d_deps])
-    imports = depset([import_root], transitive = [d.imports for d in d_deps])
-    linker_flags = depset(transitive = [d.linker_flags for d in d_deps])
-    string_imports = depset(transitive = [d.string_imports for d in d_deps])
-    versions = depset(transitive = [d.versions for d in d_deps])
-
-    args = ctx.actions.args()
-    args.add_all(COMPILATION_MODE_FLAGS[ctx.var["COMPILATION_MODE"]])
-    args.add_all(srcs)
-    args.add_all([i for i in imports.to_list() if i], format_each = "-I=%s")
-    args.add_all([si for si in string_imports.to_list() if si], format_each = "-J=%s")
-    args.add_all(toolchain.compiler_flags)
-    args.add_all(compiler_flags.to_list())
-    args.add_all([v for v in versions.to_list() if v], format_each = "-version=%s")
-    args.add("-lib")
-
-    output = ctx.actions.declare_file(static_library_name(ctx, ctx.label.name))
-    args.add(output, format = "-of=%s")
-
-    ctx.actions.run(
-        inputs = depset(
-            direct = srcs,
-            transitive = [toolchain.d_compiler[DefaultInfo].default_runfiles.files] +
-                         [d.interface_srcs for d in d_deps],
-        ),
-        outputs = [output],
-        executable = toolchain.d_compiler[DefaultInfo].files_to_run,
-        arguments = [args],
-        env = ctx.var,
-        use_default_shell_env = False,
-        mnemonic = "Dcompile",
-        progress_message = "Compiling D proto library %s" % ctx.label.name,
-        toolchain = "@rules_d//d:toolchain_type",
-    )
-
-    linker_input = cc_common.create_linker_input(
-        owner = ctx.label,
-        libraries = depset(direct = [cc_common.create_library_to_link(
-            actions = ctx.actions,
-            static_library = output,
-        )]),
-    )
-    linking_context = cc_common.create_linking_context(
-        linker_inputs = depset(
-            direct = [linker_input],
-            transitive = [
-                d.linking_context.linker_inputs
-                for d in c_deps + d_deps
-            ],
-        ),
-    )
-    return DInfo(
-        compilation_output = output,
-        compiler_flags = compiler_flags,
-        imports = depset(
-            [import_root, paths.join(ctx.label.workspace_root, ctx.label.package)],
-            transitive = [d.imports for d in d_deps],
-        ),
-        interface_srcs = depset(srcs, transitive = [d.interface_srcs for d in d_deps]),
-        linking_context = linking_context,
-        linker_flags = linker_flags,
-        string_imports = string_imports,
         versions = versions,
     )

--- a/d/private/rules/compile.bzl
+++ b/d/private/rules/compile.bzl
@@ -58,7 +58,7 @@ TARGET_TYPE = struct(
     TEST = "test",
 )
 
-def compilation_action(ctx, target_type = TARGET_TYPE.LIBRARY):
+def d_compile(ctx, target_type = TARGET_TYPE.LIBRARY):
     """Defines a compilation action for D source files.
 
     Args:
@@ -160,5 +160,84 @@ def compilation_action(ctx, target_type = TARGET_TYPE.LIBRARY):
             [paths.join(ctx.label.workspace_root, ctx.label.package, imp) for imp in ctx.attr.string_imports],
             transitive = [d.string_imports for d in d_deps],
         ),
+        versions = versions,
+    )
+
+def d_proto_compile(ctx, srcs, deps, import_root):
+    """Compiles generated D proto sources into a D library.
+
+    Args:
+        ctx: The aspect context.
+        srcs: Generated D source files to compile.
+        deps: Dependency targets providing CcInfo or DInfo.
+        import_root: Import path containing the generated D sources.
+    Returns:
+        The DInfo provider containing the compilation information.
+    """
+    toolchain = ctx.toolchains["//d:toolchain_type"].d_toolchain_info
+    c_deps = [d[CcInfo] for d in deps if CcInfo in d]
+    d_deps = [d[DInfo] for d in deps if DInfo in d]
+    compiler_flags = depset(transitive = [d.compiler_flags for d in d_deps])
+    imports = depset([import_root], transitive = [d.imports for d in d_deps])
+    linker_flags = depset(transitive = [d.linker_flags for d in d_deps])
+    string_imports = depset(transitive = [d.string_imports for d in d_deps])
+    versions = depset(transitive = [d.versions for d in d_deps])
+
+    args = ctx.actions.args()
+    args.add_all(COMPILATION_MODE_FLAGS[ctx.var["COMPILATION_MODE"]])
+    args.add_all(srcs)
+    args.add_all([i for i in imports.to_list() if i], format_each = "-I=%s")
+    args.add_all([si for si in string_imports.to_list() if si], format_each = "-J=%s")
+    args.add_all(toolchain.compiler_flags)
+    args.add_all(compiler_flags.to_list())
+    args.add_all([v for v in versions.to_list() if v], format_each = "-version=%s")
+    args.add("-lib")
+
+    output = ctx.actions.declare_file(static_library_name(ctx, ctx.label.name))
+    args.add(output, format = "-of=%s")
+
+    ctx.actions.run(
+        inputs = depset(
+            direct = srcs,
+            transitive = [toolchain.d_compiler[DefaultInfo].default_runfiles.files] +
+                         [d.interface_srcs for d in d_deps],
+        ),
+        outputs = [output],
+        executable = toolchain.d_compiler[DefaultInfo].files_to_run,
+        arguments = [args],
+        env = ctx.var,
+        use_default_shell_env = False,
+        mnemonic = "Dcompile",
+        progress_message = "Compiling D proto library %s" % ctx.label.name,
+        toolchain = "@rules_d//d:toolchain_type",
+    )
+
+    linker_input = cc_common.create_linker_input(
+        owner = ctx.label,
+        libraries = depset(direct = [cc_common.create_library_to_link(
+            actions = ctx.actions,
+            static_library = output,
+        )]),
+    )
+    linking_context = cc_common.create_linking_context(
+        linker_inputs = depset(
+            direct = [linker_input],
+            transitive = [
+                d.linking_context.linker_inputs
+                for d in c_deps + d_deps
+            ],
+        ),
+    )
+    return DInfo(
+        compilation_output = output,
+        compiler_flags = compiler_flags,
+        imports = depset(
+            [import_root, paths.join(ctx.label.workspace_root, ctx.label.package)],
+            transitive = [d.imports for d in d_deps],
+        ),
+        interface_srcs = depset(srcs, transitive = [d.interface_srcs for d in d_deps]),
+        linking_context = linking_context,
+        linker_flags = linker_flags,
+        string_imports = string_imports,
         versions = versions,
     )

--- a/d/private/rules/library.bzl
+++ b/d/private/rules/library.bzl
@@ -1,11 +1,31 @@
 """Rule for compiling D libraries."""
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//d/private:providers.bzl", "DInfo")
 load("//d/private/rules:compile.bzl", "TARGET_TYPE", "d_compile", "library_attrs")
+load("//d/private/rules:utils.bzl", "static_library_name")
 
 def _d_library_impl(ctx):
     """Implementation of d_library rule."""
-    d_info = d_compile(ctx, target_type = TARGET_TYPE.LIBRARY)
+    d_info = d_compile(
+        actions = ctx.actions,
+        label = ctx.label,
+        toolchain = ctx.toolchains["//d:toolchain_type"].d_toolchain_info,
+        compilation_mode = ctx.var["COMPILATION_MODE"],
+        env = ctx.var,
+        srcs = ctx.files.srcs,
+        deps = ctx.attr.deps,
+        dopts = ctx.attr.dopts,
+        imports = [paths.join(ctx.label.workspace_root, ctx.label.package, imp) for imp in ctx.attr.imports],
+        linkopts = ctx.attr.linkopts,
+        string_srcs = ctx.files.string_srcs,
+        string_imports = ([paths.join(ctx.label.workspace_root, ctx.label.package)] if ctx.files.string_srcs else []) +
+                         [paths.join(ctx.label.workspace_root, ctx.label.package, imp) for imp in ctx.attr.string_imports],
+        versions = ctx.attr.versions,
+        output = ctx.actions.declare_file(static_library_name(ctx, ctx.label.name)),
+        target_type = TARGET_TYPE.LIBRARY,
+        source_only = ctx.attr.source_only,
+    )
     return [
         d_info,
         DefaultInfo(files = depset([d_info.compilation_output])),

--- a/d/private/rules/library.bzl
+++ b/d/private/rules/library.bzl
@@ -1,11 +1,11 @@
 """Rule for compiling D libraries."""
 
 load("//d/private:providers.bzl", "DInfo")
-load("//d/private/rules:compile.bzl", "TARGET_TYPE", "compilation_action", "library_attrs")
+load("//d/private/rules:compile.bzl", "TARGET_TYPE", "d_compile", "library_attrs")
 
 def _d_library_impl(ctx):
     """Implementation of d_library rule."""
-    d_info = compilation_action(ctx, target_type = TARGET_TYPE.LIBRARY)
+    d_info = d_compile(ctx, target_type = TARGET_TYPE.LIBRARY)
     return [
         d_info,
         DefaultInfo(files = depset([d_info.compilation_output])),

--- a/d/private/rules/proto.bzl
+++ b/d/private/rules/proto.bzl
@@ -1,0 +1,175 @@
+"""Rule for generating and compiling D libraries from proto_library targets."""
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@protobuf//bazel/common:proto_info.bzl", "ProtoInfo")
+load("@rules_cc//cc:defs.bzl", "cc_common")
+load("//d/private:providers.bzl", "DInfo")
+load("//d/private/rules:compile.bzl", "d_proto_compile")
+
+_ProtoDFilesInfo = provider(
+    doc = "Generated D proto files.",
+    fields = {"files": "Generated D source and library files."},
+)
+
+def _proto_path(src, proto, package = None):
+    if package and src.path.startswith(package + "/"):
+        return src.path[len(package) + 1:]
+    if proto.proto_source_root == ".":
+        prefix = src.root.path + "/"
+    elif proto.proto_source_root.startswith(src.root.path):
+        prefix = proto.proto_source_root + "/"
+    else:
+        prefix = paths.join(src.root.path, proto.proto_source_root) + "/"
+    if not src.path.startswith(prefix):
+        return src.path
+    return src.path[len(prefix):]
+
+def _default_out(src):
+    if not src.basename.endswith(".proto"):
+        fail("Expected a .proto source, got %s" % src.path)
+    return src.basename[:-len(".proto")] + ".d"
+
+def _generated_root(ctx):
+    if ctx.label.package:
+        return paths.join(ctx.bin_dir.path, ctx.label.package)
+    return ctx.bin_dir.path
+
+def _empty_d_info(deps):
+    d_deps = [d[DInfo] for d in deps if DInfo in d]
+    return DInfo(
+        compiler_flags = depset(transitive = [d.compiler_flags for d in d_deps]),
+        imports = depset(transitive = [d.imports for d in d_deps]),
+        interface_srcs = depset(transitive = [d.interface_srcs for d in d_deps]),
+        linker_flags = depset(transitive = [d.linker_flags for d in d_deps]),
+        linking_context = cc_common.create_linking_context(
+            linker_inputs = depset(transitive = [d.linking_context.linker_inputs for d in d_deps]),
+        ),
+        string_imports = depset(transitive = [d.string_imports for d in d_deps]),
+        versions = depset(transitive = [d.versions for d in d_deps]),
+    )
+
+def _d_proto_aspect_impl(target, ctx):
+    proto = target[ProtoInfo]
+    proto_deps = getattr(ctx.rule.attr, "deps", [])
+    d_deps = proto_deps + [ctx.attr._runtime]
+
+    if not proto.direct_sources:
+        transitive_files = [dep[_ProtoDFilesInfo].files for dep in proto_deps if _ProtoDFilesInfo in dep]
+        return [
+            _empty_d_info(proto_deps),
+            _ProtoDFilesInfo(files = depset(transitive = transitive_files)),
+        ]
+
+    direct_sources = []
+    proto_inputs = []
+    proto_paths = {}
+    proto_source_roots = {}
+    direct_proto_paths = []
+
+    for root in proto.transitive_proto_path.to_list():
+        proto_source_roots[root] = None
+    if ctx.label.package:
+        proto_source_roots[ctx.label.package] = None
+    for src in proto.direct_sources:
+        direct_sources.append(src)
+        direct_proto_paths.append(_proto_path(src, proto, ctx.label.package))
+    for src in proto.transitive_sources.to_list():
+        proto_inputs.append(src)
+        path = _proto_path(src, proto)
+        if path in proto_paths and proto_paths[path] != src:
+            fail("proto files %s and %s have the same import path %s" % (
+                src.path,
+                proto_paths[path].path,
+                path,
+            ))
+        proto_paths[path] = src
+
+    outs = [_default_out(src) for src in direct_sources]
+    generated_srcs = [ctx.actions.declare_file(out) for out in outs]
+    args = ctx.actions.args()
+    args.add("--plugin=protoc-gen-d=%s" % ctx.executable._protoc_gen_d.path)
+    args.add("--d_out=%s" % _generated_root(ctx))
+    args.add_all(proto_source_roots.keys(), before_each = "--proto_path")
+    args.add_all(direct_proto_paths)
+
+    ctx.actions.run(
+        inputs = proto_inputs,
+        outputs = generated_srcs,
+        tools = [
+            ctx.attr._protoc[DefaultInfo].files_to_run,
+            ctx.attr._protoc_gen_d[DefaultInfo].files_to_run,
+        ],
+        executable = ctx.executable._protoc,
+        arguments = [args],
+        mnemonic = "DProtoCompile",
+        progress_message = "Generating D sources from proto %s" % ctx.label.name,
+    )
+
+    d_info = d_proto_compile(
+        ctx,
+        srcs = generated_srcs,
+        deps = d_deps,
+        import_root = _generated_root(ctx),
+    )
+    transitive_files = [dep[_ProtoDFilesInfo].files for dep in proto_deps if _ProtoDFilesInfo in dep]
+    return [
+        d_info,
+        _ProtoDFilesInfo(files = depset(
+            direct = generated_srcs + [d_info.compilation_output],
+            transitive = transitive_files,
+        )),
+    ]
+
+d_proto_aspect = aspect(
+    implementation = _d_proto_aspect_impl,
+    attr_aspects = ["deps"],
+    required_providers = [ProtoInfo],
+    provides = [DInfo],
+    attrs = {
+        "_protoc": attr.label(
+            default = "@protobuf//:protoc",
+            executable = True,
+            cfg = "exec",
+        ),
+        "_protoc_gen_d": attr.label(
+            default = "@protobuf_d//protoc_gen_d:protoc-gen-d",
+            executable = True,
+            cfg = "exec",
+        ),
+        "_runtime": attr.label(
+            default = "@protobuf_d//:protobuf",
+            providers = [DInfo],
+        ),
+        "_linux_constraint": attr.label(default = "@platforms//os:linux"),
+        "_macos_constraint": attr.label(default = "@platforms//os:macos"),
+        "_windows_constraint": attr.label(default = "@platforms//os:windows"),
+    },
+    toolchains = ["//d:toolchain_type"],
+)
+
+def _d_proto_library_impl(ctx):
+    if len(ctx.attr.deps) != 1:
+        fail(
+            "'deps' attribute must contain exactly one proto_library label.",
+            attr = "deps",
+        )
+    dep = ctx.attr.deps[0]
+    return [
+        DefaultInfo(files = dep[_ProtoDFilesInfo].files),
+        dep[DInfo],
+    ]
+
+d_proto_library = rule(
+    implementation = _d_proto_library_impl,
+    attrs = {
+        "deps": attr.label_list(
+            aspects = [d_proto_aspect],
+            allow_files = False,
+            allow_rules = ["proto_library"],
+            doc = "proto_library targets to generate D code from.",
+            mandatory = True,
+            providers = [ProtoInfo],
+        ),
+    },
+    provides = [DInfo],
+)

--- a/d/private/rules/proto.bzl
+++ b/d/private/rules/proto.bzl
@@ -4,7 +4,8 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@protobuf//bazel/common:proto_info.bzl", "ProtoInfo")
 load("@rules_cc//cc:defs.bzl", "cc_common")
 load("//d/private:providers.bzl", "DInfo")
-load("//d/private/rules:compile.bzl", "d_proto_compile")
+load("//d/private/rules:compile.bzl", "d_compile")
+load("//d/private/rules:utils.bzl", "static_library_name")
 
 _ProtoDFilesInfo = provider(
     doc = "Generated D proto files.",
@@ -105,11 +106,21 @@ def _d_proto_aspect_impl(target, ctx):
         progress_message = "Generating D sources from proto %s" % ctx.label.name,
     )
 
-    d_info = d_proto_compile(
-        ctx,
+    d_info = d_compile(
+        actions = ctx.actions,
+        label = ctx.label,
+        toolchain = ctx.toolchains["//d:toolchain_type"].d_toolchain_info,
+        compilation_mode = ctx.var["COMPILATION_MODE"],
+        env = ctx.var,
         srcs = generated_srcs,
         deps = d_deps,
-        import_root = _generated_root(ctx),
+        dopts = [],
+        imports = [_generated_root(ctx)],
+        linkopts = [],
+        string_srcs = [],
+        string_imports = [],
+        versions = [],
+        output = ctx.actions.declare_file(static_library_name(ctx, ctx.label.name)),
     )
     transitive_files = [dep[_ProtoDFilesInfo].files for dep in proto_deps if _ProtoDFilesInfo in dep]
     return [

--- a/d/private/rules/test.bzl
+++ b/d/private/rules/test.bzl
@@ -1,13 +1,32 @@
 """D test rule for compiling and running D unit tests."""
 
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_variables")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "use_cc_toolchain")
 load("//d/private/rules:compile.bzl", "TARGET_TYPE", "d_compile", "runnable_attrs")
 load("//d/private/rules:link.bzl", "link_action")
+load("//d/private/rules:utils.bzl", "object_file_name")
 
 def _d_test_impl(ctx):
     """Implementation of d_test rule."""
-    d_info = d_compile(ctx, target_type = TARGET_TYPE.TEST)
+    d_info = d_compile(
+        actions = ctx.actions,
+        label = ctx.label,
+        toolchain = ctx.toolchains["//d:toolchain_type"].d_toolchain_info,
+        compilation_mode = ctx.var["COMPILATION_MODE"],
+        env = ctx.var,
+        srcs = ctx.files.srcs,
+        deps = ctx.attr.deps,
+        dopts = ctx.attr.dopts,
+        imports = [paths.join(ctx.label.workspace_root, ctx.label.package, imp) for imp in ctx.attr.imports],
+        linkopts = ctx.attr.linkopts,
+        string_srcs = ctx.files.string_srcs,
+        string_imports = ([paths.join(ctx.label.workspace_root, ctx.label.package)] if ctx.files.string_srcs else []) +
+                         [paths.join(ctx.label.workspace_root, ctx.label.package, imp) for imp in ctx.attr.string_imports],
+        versions = ctx.attr.versions,
+        output = ctx.actions.declare_file(object_file_name(ctx, ctx.label.name)),
+        target_type = TARGET_TYPE.TEST,
+    )
     output = link_action(ctx, d_info)
     env_with_expansions = {
         k: expand_variables(ctx, ctx.expand_location(v, ctx.attr.data), [output], "env")

--- a/d/private/rules/test.bzl
+++ b/d/private/rules/test.bzl
@@ -2,12 +2,12 @@
 
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_variables")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "use_cc_toolchain")
-load("//d/private/rules:compile.bzl", "TARGET_TYPE", "compilation_action", "runnable_attrs")
+load("//d/private/rules:compile.bzl", "TARGET_TYPE", "d_compile", "runnable_attrs")
 load("//d/private/rules:link.bzl", "link_action")
 
 def _d_test_impl(ctx):
     """Implementation of d_test rule."""
-    d_info = compilation_action(ctx, target_type = TARGET_TYPE.TEST)
+    d_info = d_compile(ctx, target_type = TARGET_TYPE.TEST)
     output = link_action(ctx, d_info)
     env_with_expansions = {
         k: expand_variables(ctx, ctx.expand_location(v, ctx.attr.data), [output], "env")

--- a/d/repositories.bzl
+++ b/d/repositories.bzl
@@ -42,19 +42,19 @@ def rules_d_dependencies():
         url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v30.2.tar.gz",
     )
 
-def protobuf_d_dependencies(name = "protobuf_d", version = "0.7.0", integrity = "sha256-LM6v/r8kTNl58zvc1v8LHxPkKLYoVbKoXMornDxMfUg=", sha256 = ""):
+def protobuf_d_dependencies(name = "protobuf_d", version = "0.7.0", integrity = "sha256-AKNEUJlnV4gheWFEEaq92dyzmy94HhCMjE9zgxoP/9I=", sha256 = ""):
     """Fetches the protobuf DUB package used by d_proto_library.
 
     Args:
         name: Repository name for the protobuf DUB package.
         version: DUB package version.
-        integrity: Optional SRI integrity for the GitHub release archive.
-        sha256: Optional sha256 for the GitHub release archive.
+        integrity: Optional SRI integrity for the DUB package archive.
+        sha256: Optional sha256 for the DUB package archive.
     """
     kwargs = {
         "strip_prefix": "protobuf-d-%s" % version,
         "urls": [
-            "https://github.com/dcarp/protobuf-d/archive/refs/tags/v%s.tar.gz" % version,
+            "https://code.dlang.org/packages/protobuf/%s.zip" % version,
         ],
     }
     if integrity:

--- a/d/repositories.bzl
+++ b/d/repositories.bzl
@@ -35,6 +35,33 @@ def rules_d_dependencies():
         strip_prefix = "supply-chain-0.0.6/metadata",
         url = "https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.6/supply-chain-v0.0.6.tar.gz",
     )
+    http_archive(
+        name = "protobuf",
+        sha256 = "07a43d88fe5a38e434c7f94129cad56a4c43a51f99336074d0799c2f7d4e44c5",
+        strip_prefix = "protobuf-30.2",
+        url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v30.2.tar.gz",
+    )
+
+def protobuf_d_dependencies(name = "protobuf_d", version = "0.7.0", integrity = "sha256-LM6v/r8kTNl58zvc1v8LHxPkKLYoVbKoXMornDxMfUg=", sha256 = ""):
+    """Fetches the protobuf DUB package used by d_proto_library.
+
+    Args:
+        name: Repository name for the protobuf DUB package.
+        version: DUB package version.
+        integrity: Optional SRI integrity for the GitHub release archive.
+        sha256: Optional sha256 for the GitHub release archive.
+    """
+    kwargs = {
+        "strip_prefix": "protobuf-d-%s" % version,
+        "urls": [
+            "https://github.com/dcarp/protobuf-d/archive/refs/tags/v%s.tar.gz" % version,
+        ],
+    }
+    if integrity:
+        kwargs["integrity"] = integrity
+    if sha256:
+        kwargs["sha256"] = sha256
+    http_archive(name = name, **kwargs)
 
 ########
 # Remaining content of the file is only used to support toolchains.

--- a/d/tests/proto/BUILD.bazel
+++ b/d/tests/proto/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_d//d:defs.bzl", "d_binary", "d_proto_library")
+
+proto_library(
+    name = "common_proto",
+    srcs = ["common.proto"],
+    tags = ["manual"],
+)
+
+proto_library(
+    name = "addressbook_proto",
+    srcs = ["addressbook.proto"],
+    tags = ["manual"],
+    deps = [":common_proto"],
+)
+
+d_proto_library(
+    name = "addressbook_d_proto",
+    deps = [":addressbook_proto"],
+)
+
+d_binary(
+    name = "addressbook_usage",
+    srcs = ["usage.d"],
+    deps = [":addressbook_d_proto"],
+)
+
+build_test(
+    name = "addressbook_usage_test",
+    targets = [":addressbook_usage"],
+)

--- a/d/tests/proto/addressbook.proto
+++ b/d/tests/proto/addressbook.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+import "common.proto";
+
+message Person {
+  string name = 1;
+  Email email = 2;
+}

--- a/d/tests/proto/common.proto
+++ b/d/tests/proto/common.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Email {
+  string value = 1;
+}

--- a/d/tests/proto/usage.d
+++ b/d/tests/proto/usage.d
@@ -1,0 +1,8 @@
+import addressbook;
+
+void main()
+{
+    Person person;
+    person.name = "Ada";
+    assert(person.name == "Ada");
+}

--- a/e2e/smoke/.bazelrc
+++ b/e2e/smoke/.bazelrc
@@ -3,6 +3,9 @@ import ../../tools/preset.bazelrc
 
 # project-specific settings
 startup --windows_enable_symlinks
+# Protobuf's upb tool sources require C++17 when built by Bazel 7.
+common --host_cxxopt=-std=c++17
+common --cxxopt=-std=c++17
 common:ci --lockfile_mode=off
 
 # Keep the disk cache out of Bazel's own output base hierarchy.

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -6,6 +6,7 @@ load("@rules_d//dub:defs.bzl", "dub_lock_dependencies")
 build_test(
     name = "smoke_test",
     targets = [
+        "//tests/proto:addressbook_d_proto",
         "//tests/std_lib:fiber_thread_usage",
     ],
 )

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,6 +1,7 @@
 bazel_dep(name = "rules_d", version = "0.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "protobuf", version = "30.2")
 
 local_path_override(
     module_name = "rules_d",
@@ -12,3 +13,6 @@ dub.from_dub_selections(
     dub_selections_lock = "//:dub.selections.lock.json",
 )
 use_repo(dub, "dub")
+
+protobuf_d = use_extension("@rules_d//d:extensions.bzl", "protobuf_d")
+use_repo(protobuf_d, "protobuf_d")

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -45,15 +45,15 @@ load("@bazel_features//:deps.bzl", "bazel_features_deps")
 bazel_features_deps()
 
 http_archive(
-    name = "com_google_protobuf",
-    sha256 = "10a0d58f39a1a909e95e00e8ba0b5b1dc64d02997f741151953a2b3659f6e78c",
-    strip_prefix = "protobuf-29.0",
-    url = "https://github.com/protocolbuffers/protobuf/releases/download/v29.0/protobuf-29.0.tar.gz",
+    name = "protobuf",
+    sha256 = "07a43d88fe5a38e434c7f94129cad56a4c43a51f99336074d0799c2f7d4e44c5",
+    strip_prefix = "protobuf-30.2",
+    url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v30.2.tar.gz",
 )
 
-load("@com_google_protobuf//bazel/private:proto_bazel_features.bzl", "proto_bazel_features")  # buildifier: disable=bzl-visibility
+load("@protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
-proto_bazel_features(name = "proto_bazel_features")
+protobuf_deps()
 
 http_archive(
     name = "rules_cc",
@@ -91,7 +91,7 @@ http_archive(
 # you should fetch it *before* calling this.
 # Alternatively, you can skip calling this function, so long as you've
 # already fetched all the dependencies.
-load("@rules_d//d:repositories.bzl", "d_register_toolchains", "rules_d_dependencies")
+load("@rules_d//d:repositories.bzl", "d_register_toolchains", "protobuf_d_dependencies", "rules_d_dependencies")
 load("@rules_d//dub:repositories.bzl", "d_register_dub_repository")
 
 rules_d_dependencies()
@@ -99,6 +99,8 @@ rules_d_dependencies()
 d_register_dub_repository(
     dub_selections_lock = "//:dub.selections.lock.json",
 )
+
+protobuf_d_dependencies()
 
 d_register_toolchains(
     "dmd_toolchain",

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -45,17 +45,6 @@ load("@bazel_features//:deps.bzl", "bazel_features_deps")
 bazel_features_deps()
 
 http_archive(
-    name = "protobuf",
-    sha256 = "07a43d88fe5a38e434c7f94129cad56a4c43a51f99336074d0799c2f7d4e44c5",
-    strip_prefix = "protobuf-30.2",
-    url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v30.2.tar.gz",
-)
-
-load("@protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()
-
-http_archive(
     name = "rules_cc",
     sha256 = "92fed78a5a310f86c060dcaed20f396ef0198cc3d46a46fdea7c469042cf02ce",
     strip_prefix = "rules_cc-0.2.1",
@@ -71,6 +60,33 @@ rules_cc_toolchains()
 load("@rules_cc//cc:extensions.bzl", "compatibility_proxy_repo")
 
 compatibility_proxy_repo()
+
+http_archive(
+    name = "protobuf",
+    sha256 = "07a43d88fe5a38e434c7f94129cad56a4c43a51f99336074d0799c2f7d4e44c5",
+    strip_prefix = "protobuf-30.2",
+    url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v30.2.tar.gz",
+)
+
+# Bazel 7's @bazel_tools//tools/proto targets still reference this legacy repo name.
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "07a43d88fe5a38e434c7f94129cad56a4c43a51f99336074d0799c2f7d4e44c5",
+    strip_prefix = "protobuf-30.2",
+    url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v30.2.tar.gz",
+)
+
+load("@protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+load("@rules_java//java:rules_java_deps.bzl", java_compatibility_proxy_repo = "compatibility_proxy_repo")
+
+java_compatibility_proxy_repo()
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
 
 http_archive(
     name = "platforms",

--- a/e2e/smoke/tests/proto/BUILD.bazel
+++ b/e2e/smoke/tests/proto/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_d//d:defs.bzl", "d_proto_library", "d_test")
+
+proto_library(
+    name = "addressbook_proto",
+    srcs = ["addressbook.proto"],
+)
+
+d_proto_library(
+    name = "addressbook_d_proto",
+    visibility = ["//visibility:public"],
+    deps = [":addressbook_proto"],
+)
+
+d_test(
+    name = "addressbook_usage",
+    srcs = ["usage.d"],
+    visibility = ["//visibility:public"],
+    deps = [":addressbook_d_proto"],
+)

--- a/e2e/smoke/tests/proto/addressbook.proto
+++ b/e2e/smoke/tests/proto/addressbook.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Person {
+  string name = 1;
+}

--- a/e2e/smoke/tests/proto/usage.d
+++ b/e2e/smoke/tests/proto/usage.d
@@ -1,0 +1,9 @@
+import addressbook;
+
+unittest
+{
+    auto person = new Person();
+    person.name = "Ada";
+
+    assert(person.name == "Ada");
+}


### PR DESCRIPTION
  ## Summary

  Adds `d_proto_library` for generating and compiling D code from `proto_library` targets.

  This uses Protobuf’s Bazel-provided `ProtoInfo` and `protoc`, plus the `protobuf-d` v0.7.0 runtime/compiler plugin exposed as `@protobuf_d`. The rule  follows the modern `<lang>_proto_library` shape where proto inputs are provided through `deps`.

  ## Changes

  - Add `d_proto_library` and `d_proto_aspect`
  - Generate D sources with `@protobuf//:protoc` and `@protobuf_d//protoc_gen_d:protoc-gen-d`
  - Compile generated D sources through the shared `d_compile` helper
  - Add `protobuf` 30.2 and `protobuf_d` repository setup for Bzlmod and WORKSPACE
  - Refactor `d_compile`/`d_proto_compile` to take explicit action inputs instead of full rule context
  - Add in-repo proto coverage, including transitive proto deps
  - Add e2e smoke coverage for `d_proto_library` in both Bzlmod and WORKSPACE setup

  ## Testing

  - `bazel test //...`
  - `bazel test //...` from `e2e/smoke`
  - `USE_BAZEL_VERSION=8.4.2 bazel --output_base=/tmp/rules_d_e2e_workspace_bazel_8_4_2 test //... --enable_workspace --noenable_bzlmod`