### PR TITLE
feat(dub): support multi-source lock generation

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,9 +26,6 @@ bazel_dep(name = "rules_go", version = "0.59.0", dev_dependency = True)  # For g
 d = use_extension("//d:extensions.bzl", "d")
 d.toolchain(d_version = "dmd-2.112.0")
 d.toolchain(d_version = "ldc-1.41.0")
-use_repo(d, "d_toolchains")
-
-protobuf_d = use_extension("//d:extensions.bzl", "protobuf_d")
-use_repo(protobuf_d, "protobuf_d")
+use_repo(d, "d_toolchains", "rules_d__protobuf_d", "rules_d__semver")
 
 register_toolchains("@d_toolchains//:all")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -238,35 +238,6 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
-    "//d:extensions.bzl%protobuf_d": {
-      "general": {
-        "bzlTransitiveDigest": "nnDcbNC+3MG3ddypeceZmkZyfVmahP+WHg9ZuXGqXPA=",
-        "usagesDigest": "WZkd19+Smea+t678N9IvTHAtUEaxmn1sv7+yHEix6HM=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "protobuf_d": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "strip_prefix": "protobuf-d-0.7.0",
-              "urls": [
-                "https://code.dlang.org/packages/protobuf/0.7.0.zip"
-              ],
-              "integrity": "sha256-AKNEUJlnV4gheWFEEaq92dyzmy94HhCMjE9zgxoP/9I="
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    },
     "@@aspect_bazel_lib~//lib:extensions.bzl%toolchains": {
       "general": {
         "bzlTransitiveDigest": "a8tWABvj0Atq3WKbFAzcdfrByxB6/D+I6P+NXTkvIjE=",

--- a/d/extensions.bzl
+++ b/d/extensions.bzl
@@ -10,7 +10,7 @@ names (the latest version will be picked for each name) and can register them as
 effectively overriding the default named toolchain due to toolchain resolution precedence.
 """
 
-load(":repositories.bzl", "d_register_toolchains", "protobuf_d_dependencies", "select_compiler_by_os")
+load(":repositories.bzl", "d_register_toolchains", "dub_dependency", "select_compiler_by_os")
 
 _DEFAULT_NAME = "d"
 
@@ -27,6 +27,20 @@ and fails if none match.
 })
 
 def _toolchain_extension(module_ctx):
+    dub_dependency(
+        name = "rules_d__protobuf_d",
+        package = "protobuf",
+        version = "0.7.0",
+        integrity = "sha256-AKNEUJlnV4gheWFEEaq92dyzmy94HhCMjE9zgxoP/9I=",
+        strip_prefix = "protobuf-d-0.7.0",
+    )
+    dub_dependency(
+        name = "rules_d__semver",
+        package = "semver",
+        version = "0.8.0",
+        sha256 = "144c8c9c0e308a4e226baeebcb6e0b335ab3b92d9a868bead5d61db4029b7e43",
+    )
+
     registrations = {}
     for mod in module_ctx.modules:
         for toolchain in mod.tags.toolchain:
@@ -64,11 +78,4 @@ d = module_extension(
     # regardless of the host platform.
     os_dependent = False,
     arch_dependent = False,
-)
-
-def _protobuf_d_extension(_module_ctx):
-    protobuf_d_dependencies()
-
-protobuf_d = module_extension(
-    implementation = _protobuf_d_extension,
 )

--- a/d/private/rules/proto.bzl
+++ b/d/private/rules/proto.bzl
@@ -143,12 +143,12 @@ d_proto_aspect = aspect(
             cfg = "exec",
         ),
         "_protoc_gen_d": attr.label(
-            default = "@protobuf_d//protoc_gen_d:protoc-gen-d",
+            default = "@rules_d__protobuf_d//protoc_gen_d:protoc-gen-d",
             executable = True,
             cfg = "exec",
         ),
         "_runtime": attr.label(
-            default = "@protobuf_d//:protobuf",
+            default = "@rules_d__protobuf_d//:protobuf",
             providers = [DInfo],
         ),
         "_linux_constraint": attr.label(default = "@platforms//os:linux"),

--- a/d/repositories.bzl
+++ b/d/repositories.bzl
@@ -20,6 +20,8 @@ def http_archive(name, **kwargs):
 # and released only in semver majors.
 # This is all fixed by bzlmod, so we just tolerate it for now.
 def rules_d_dependencies():
+    """Fetches external repositories required by rules_d."""
+
     # The minimal version of bazel_skylib we require
     http_archive(
         name = "bazel_skylib",
@@ -41,20 +43,35 @@ def rules_d_dependencies():
         strip_prefix = "protobuf-30.2",
         url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v30.2.tar.gz",
     )
+    dub_dependency(
+        name = "rules_d__protobuf_d",
+        package = "protobuf",
+        version = "0.7.0",
+        integrity = "sha256-AKNEUJlnV4gheWFEEaq92dyzmy94HhCMjE9zgxoP/9I=",
+        strip_prefix = "protobuf-d-0.7.0",
+    )
+    dub_dependency(
+        name = "rules_d__semver",
+        package = "semver",
+        version = "0.8.0",
+        sha256 = "144c8c9c0e308a4e226baeebcb6e0b335ab3b92d9a868bead5d61db4029b7e43",
+    )
 
-def protobuf_d_dependencies(name = "protobuf_d", version = "0.7.0", integrity = "sha256-AKNEUJlnV4gheWFEEaq92dyzmy94HhCMjE9zgxoP/9I=", sha256 = ""):
-    """Fetches the protobuf DUB package used by d_proto_library.
+def dub_dependency(name, package, version, integrity = "", sha256 = "", strip_prefix = ""):
+    """Fetches a DUB package as an external repository.
 
     Args:
-        name: Repository name for the protobuf DUB package.
+        name: Repository name for the DUB package.
+        package: DUB package name.
         version: DUB package version.
         integrity: Optional SRI integrity for the DUB package archive.
         sha256: Optional sha256 for the DUB package archive.
+        strip_prefix: Optional archive strip prefix. Defaults to `{package}-{version}`.
     """
     kwargs = {
-        "strip_prefix": "protobuf-d-%s" % version,
+        "strip_prefix": strip_prefix or "%s-%s" % (package, version),
         "urls": [
-            "https://code.dlang.org/packages/protobuf/%s.zip" % version,
+            "https://code.dlang.org/packages/%s/%s.zip" % (package, version),
         ],
     }
     if integrity:

--- a/dub/selections_lock/BUILD.bazel
+++ b/dub/selections_lock/BUILD.bazel
@@ -10,7 +10,10 @@ d_binary(
         "DUB": "$(location //d:dub)",
     },
     visibility = ["//visibility:public"],
-    deps = ["//dub/private:d_utils"],
+    deps = [
+        "//dub/private:d_utils",
+        "@rules_d__semver//:semver",
+    ],
 )
 
 bzl_library(

--- a/dub/selections_lock/generate_selections_lock.d
+++ b/dub/selections_lock/generate_selections_lock.d
@@ -1,6 +1,6 @@
 module dub.selections_lock.generate_selections_lock;
 
-import std.algorithm : canFind, each, find, filter, map, startsWith;
+import std.algorithm : canFind, each, find, filter, map, sort, startsWith;
 import std.array : array, assocArray, replace;
 import std.conv : to;
 import std.exception : enforce;
@@ -14,6 +14,8 @@ import std.stdio : File, toFile;
 import std.typecons : Flag, tuple;
 
 import integrity_hash : computeIntegrityHash;
+import mvs : ModuleVersion, minimalVersionSelection;
+import semver : SemVer, SemVerRange;
 
 struct Config
 {
@@ -130,12 +132,55 @@ Package[] readDubDependencies(string filePath)
     auto fileName = filePath.baseName;
     if (fileName == "dub.selections.json")
         return filePath.readText.parseDubSelectionsJson;
-    if (fileName == "dub.json" || fileName == "dub.sdl")
+    if (fileName.endsWith(".json"))
+    {
+        auto content = filePath.readText;
+        auto json = content.parseJSON;
+        if (json.type == JSONType.object &&
+            "fileVersion" in json.object &&
+            "versions" in json.object)
+            return content.parseDubSelectionsJson;
+        return filePath.generateDubSelectionsJson.parseDubSelectionsJson;
+    }
+    if (fileName == "dub.sdl")
         return filePath.generateDubSelectionsJson.parseDubSelectionsJson;
 
-    enforce(false, "Unsupported input file %s. Expected dub.json, dub.sdl, or dub.selections.json.".format(
+    enforce(false, "Unsupported input file %s. Expected JSON selections, dub.json, or dub.sdl.".format(
             filePath));
     return [];
+}
+
+Package[] resolveDubDependencies(Package[] packages)
+{
+    enum rootVersion = "0.0.0";
+    enum rootPrefix = "__rules_d_dub_lock_root_";
+    SemVerRange[string] rootConstraints;
+    SemVer[][string] availableVersions;
+    SemVerRange[string][ModuleVersion] dependencies;
+    Package[ModuleVersion] packageByVersion;
+
+    foreach (i, package_; packages)
+    {
+        auto semVer = SemVer(package_.version_);
+        enforce(semVer.isValid, "Invalid semantic version '%s' for package %s.".format(
+                package_.version_, package_.name));
+        auto rootName = rootPrefix ~ i.to!string;
+        rootConstraints[rootName] = SemVerRange(">=" ~ rootVersion);
+        availableVersions[rootName] = [SemVer(rootVersion)];
+        dependencies[ModuleVersion(rootName, SemVer(rootVersion))] = [
+            package_.name: SemVerRange(">=" ~ package_.version_),
+        ];
+        availableVersions[package_.name] ~= semVer;
+        packageByVersion[ModuleVersion(package_.name, semVer)] = package_;
+    }
+
+    auto selectedVersions = minimalVersionSelection(rootConstraints, availableVersions, dependencies);
+    return selectedVersions.byKeyValue
+        .filter!(item => !item.key.startsWith(rootPrefix))
+        .array
+        .sort!((a, b) => a.key < b.key)
+        .map!(item => packageByVersion[ModuleVersion(item.key, item.value)])
+        .array;
 }
 
 void download(Package package_)
@@ -417,7 +462,7 @@ int main(string[] args)
     string bazelGeneratingTarget;
     string cachePath;
     string dub;
-    string inputFilePath;
+    string[] inputFilePaths;
     string outputFilePath;
     bool skipSSLVerification;
     bool verbose;
@@ -426,7 +471,7 @@ int main(string[] args)
         "bazel_generating_target|b", "Document the bazel generating target.", &bazelGeneratingTarget,
         "cache_path|c", "Path to dub cache.", &cachePath,
         "dub|d", "Path to dub executable.", &dub,
-        "input|i", "Input file path. One of dub.json, dub.sdl or, dub.selections.json.", &inputFilePath,
+        "input|i", "Input file path. May be repeated. One of dub.json, dub.sdl or, dub.selections.json.", &inputFilePaths,
         "output|o", "Output dub.selections.lock.json file path.", &outputFilePath,
         "skip_ssl_verification|s", "Skip SSL verification when downloading packages.", &skipSSLVerification,
         "verbose|v", "Enable verbose output.", &verbose,
@@ -435,14 +480,22 @@ int main(string[] args)
     if (parseArgs.helpWanted)
     {
         defaultGetoptPrinter(
-            "Generates a dub.selections.lock.json file from a dub.json, dub.sdl or, dub.selections.json.",
+            "Generates a dub.selections.lock.json file from one or more dub.json, dub.sdl or, dub.selections.json inputs.",
             parseArgs.options);
         return 0;
     }
-    if (!inputFilePath.exists || !inputFilePath.isFile)
+    if (inputFilePaths.empty)
     {
-        writefln("Input file path %s does not exist or is not a file.", inputFilePath);
+        writeln("At least one input file path must be specified.");
         return 1;
+    }
+    foreach (inputFilePath; inputFilePaths)
+    {
+        if (!inputFilePath.exists || !inputFilePath.isFile)
+        {
+            writefln("Input file path %s does not exist or is not a file.", inputFilePath);
+            return 1;
+        }
     }
     if (outputFilePath.exists && !outputFilePath.isFile)
     {
@@ -462,7 +515,11 @@ int main(string[] args)
             Flag!"SkipSSLVerification"),
         verbose.to!(Flag!"Verbose"));
 
-    auto packages = readDubDependencies(inputFilePath);
+    auto packages = inputFilePaths
+        .map!(inputFilePath => readDubDependencies(inputFilePath))
+        .join
+        .array
+        .resolveDubDependencies;
     packages.each!((ref p) => p.integrity = computePackageIntegrity(p));
     packages.each!((ref p) => p.targets = describePackage(p, p.mainTargetName));
     auto targetNameByPackage = packages.map!(p => tuple(p.name, p.mainTargetName)).assocArray;

--- a/dub/selections_lock/selections_lock.bzl
+++ b/dub/selections_lock/selections_lock.bzl
@@ -6,7 +6,7 @@ load("@bazel_lib//lib:write_source_files.bzl", "write_source_file")
 
 def dub_lock_dependencies(
         name,
-        src = None,
+        srcs = None,
         dub_selections_lock = None,
         skip_ssl_verification = False,
         verbose = False,
@@ -15,7 +15,7 @@ def dub_lock_dependencies(
 
     Args:
         name: The dub dependencies target.
-        src: file containing the dub dependencies. Supported inputs are:
+        srcs: list of files containing the dub dependencies. Supported inputs are:
             * dub.sdl
             * dub.json
             * dub.selections.json
@@ -35,17 +35,13 @@ def dub_lock_dependencies(
     run_binary(
         name = name,
         tool = "@rules_d//dub/selections_lock:generate_selections_lock",
-        srcs = [
-            src,
-            "@rules_d//d:dub",
-        ],
+        srcs = srcs + ["@rules_d//d:dub"],
         args = [
             "--bazel_generating_target=//{}:{}".format(native.package_name(), update_target_name),
-            "--input=$(location {})".format(src),
             "--output=$(location {})".format(out_file),
             "--skip_ssl_verification={}".format(skip_ssl_verification),
             "--verbose={}".format(verbose),
-        ],
+        ] + ["--input=$(location {})".format(src) for src in srcs],
         env = {
             "DUB": "$(location @rules_d//d:dub)",
         },

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -13,7 +13,10 @@ build_test(
 
 dub_lock_dependencies(
     name = "dub_dependencies",
-    src = "dub.selections.json",
+    srcs = [
+        "dub.selections.extra.json",
+        "dub.selections.json",
+    ],
     dub_selections_lock = "dub.selections.lock.json",
     tags = ["manual"],
 )

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -13,6 +13,3 @@ dub.from_dub_selections(
     dub_selections_lock = "//:dub.selections.lock.json",
 )
 use_repo(dub, "dub")
-
-protobuf_d = use_extension("@rules_d//d:extensions.bzl", "protobuf_d")
-use_repo(protobuf_d, "protobuf_d")

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -107,7 +107,7 @@ http_archive(
 # you should fetch it *before* calling this.
 # Alternatively, you can skip calling this function, so long as you've
 # already fetched all the dependencies.
-load("@rules_d//d:repositories.bzl", "d_register_toolchains", "protobuf_d_dependencies", "rules_d_dependencies")
+load("@rules_d//d:repositories.bzl", "d_register_toolchains", "rules_d_dependencies")
 load("@rules_d//dub:repositories.bzl", "d_register_dub_repository")
 
 rules_d_dependencies()
@@ -115,8 +115,6 @@ rules_d_dependencies()
 d_register_dub_repository(
     dub_selections_lock = "//:dub.selections.lock.json",
 )
-
-protobuf_d_dependencies()
 
 d_register_toolchains(
     "dmd_toolchain",

--- a/e2e/smoke/dub.selections.extra.json
+++ b/e2e/smoke/dub.selections.extra.json
@@ -1,0 +1,6 @@
+{
+  "fileVersion": 1,
+  "versions": {
+    "semver": "0.7.0"
+  }
+}


### PR DESCRIPTION
 ## Summary

  - Add multi-source support to `dub_lock_dependencies` via the new `srcs` attr.
  - Combine selections from multiple DUB input files using `semver` 0.8.0 Minimal Version Selection.
  - Add a generic `dub_dependency` helper for DUB package repositories.
  - Fetch internal DUB tool repos with `rules_d__` prefixes to avoid user repo name collisions.
  - Update the smoke fixture to cover multi-source lock generation.

  ## Verification

  - `bazel build //dub/selections_lock:generate_selections_lock`
  - `bazel build //d/tests/proto:addressbook_d_proto`
  - `bazel build //:dub_dependencies.update`
  - `bazel build //:dub_dependencies.update --enable_workspace --noenable_bzlmod`