### PR TITLE
chore: use a bazel-contrib/.github workflow with enabled disk cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -37,8 +37,6 @@ common:windows --cxxopt=/std:c++17
 # Protobuf 30.x requires an explicit opt-in for MSVC builds.
 common:windows --define=protobuf_allow_msvc=true
 
-# Keep the disk cache out of Bazel's own output base hierarchy.
-common:ci --disk_cache=~/.cache/bazel/disk_cache
 test:ci --test_env=XDG_CACHE_HOME
 
 # Load user-specific settings, if any

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 jobs:
   test:
-    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@af28703814cf26522cf5e44d219efece91293123 # v7.4.0
+    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@7e9a9d6849976a5b143c8bf10b37e419eeadf6c8 # v7.5.0
     with:
       bazel_versions: |
         [
@@ -32,6 +32,7 @@ jobs:
         [
           {"folder": ".", "bzlmodEnabled": false}
         ]
+      cache_save: ${{ github.event_name != 'pull_request' }}
       bazel_test_command: bazel test --config=ci //...
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ permissions:
   contents: write
 jobs:
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.4.0 # renovate:ignore af28703814cf26522cf5e44d219efece91293123
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.5.0 # renovate:ignore 7e9a9d6849976a5b143c8bf10b37e419eeadf6c8
     with:
       release_files: rules_d-*.tar.gz
       prerelease: false

--- a/e2e/smoke/.bazelrc
+++ b/e2e/smoke/.bazelrc
@@ -14,6 +14,4 @@ common:windows --cxxopt=/std:c++17
 common:windows --define=protobuf_allow_msvc=true
 common:ci --lockfile_mode=off
 
-# Keep the disk cache out of Bazel's own output base hierarchy.
-common:ci --disk_cache=~/.cache/bazel/disk_cache
 test:ci --test_env=XDG_CACHE_HOME


### PR DESCRIPTION
Update to bazel-contrib/.github v7.5.0 with disk-cache enabled.