### PR TITLE
feat: add dmd-2.112.1 and ldc-1.42.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,8 +23,8 @@ bazel_dep(name = "rules_go", version = "0.59.0", dev_dependency = True)  # For g
 
 # Select first d toolchain available for the current platform.
 d = use_extension("//d:extensions.bzl", "d")
-d.toolchain(d_version = "dmd-2.112.0")
-d.toolchain(d_version = "ldc-1.41.0")
+d.toolchain(d_version = "dmd-2.112.0")  # dmd-2.112.1 uses a .7z archive on windows, which requires Bazel 9+.
+d.toolchain(d_version = "ldc-1.42.0")
 use_repo(d, "d_toolchains", "rules_d__protobuf_d", "rules_d__semver")
 
 register_toolchains("@d_toolchains//:all")

--- a/d/private/sdk/versions.bzl
+++ b/d/private/sdk/versions.bzl
@@ -706,6 +706,20 @@ SDK_VERSIONS = {
             "integrity": "sha384-UQqEzWgYPA3+ir36kCurs7vJDwNrgcKzqC19UvhijwcehP3htkWFT6auEZCDq8Dl",
         },
     },
+    "dmd-2.112.1": {
+        "x86_64-unknown-linux-gnu": {
+            "url": "https://downloads.dlang.org/releases/2.x/2.112.1/dmd.2.112.1.linux.tar.xz",
+            "integrity": "sha384-Rqcnr3z++ntbptQ9QvN/3yjfV5hq1ZGUw+SeLJStYGMXafiqTg2vtOcm00cBTfuN",
+        },
+        "x86_64-apple-darwin": {
+            "url": "https://downloads.dlang.org/releases/2.x/2.112.1/dmd.2.112.1.osx.tar.xz",
+            "integrity": "sha384-cIf0O5QDHqUTccJCjbX+ZoFu9k+sCjp6B419hvYouaU9Gt0yARgZNFlh6ulcVbSp",
+        },
+        "x86_64-pc-windows-msvc": {
+            "url": "https://downloads.dlang.org/releases/2.x/2.112.1/dmd.2.112.1.windows.7z",
+            "integrity": "sha384-1A0ayv3lLNKRwDsOx/ANRLu7BEngnf3rUryR6GDSwj6vSB8iQhMkc+TTvBfBj9en",
+        },
+    },
     "ldc-1.20.0": {
         "aarch64-unknown-linux-gnu": {
             "url": "https://github.com/ldc-developers/ldc/releases/download/v1.20.0/ldc2-1.20.0-linux-aarch64.tar.xz",
@@ -1194,6 +1208,24 @@ SDK_VERSIONS = {
         "x86_64-apple-darwin": {
             "url": "https://github.com/ldc-developers/ldc/releases/download/v1.41.0/ldc2-1.41.0-osx-x86_64.tar.xz",
             "integrity": "sha384-Fmbq2sAUplXQIceDail9Ylxy21QM1rgAm32tBUl/qXPux+p8NeDg5FRfsANywdhK",
+        },
+    },
+    "ldc-1.42.0": {
+        "aarch64-unknown-linux-gnu": {
+            "url": "https://github.com/ldc-developers/ldc/releases/download/v1.42.0/ldc2-1.42.0-linux-aarch64.tar.xz",
+            "integrity": "sha384-iareytuuERj/DiZFXsbMU4bPYVIpYMj9Or9OW7uAYofxrD5/ShWWP5hI571Prity",
+        },
+        "x86_64-unknown-linux-gnu": {
+            "url": "https://github.com/ldc-developers/ldc/releases/download/v1.42.0/ldc2-1.42.0-linux-x86_64.tar.xz",
+            "integrity": "sha384-AYt7QVV+0PfA9cxg25bne4lLFiMqEG7fzH1jbHq2o/zCgZMyKuw0iO3sOY1MO2gZ",
+        },
+        "aarch64-apple-darwin": {
+            "url": "https://github.com/ldc-developers/ldc/releases/download/v1.42.0/ldc2-1.42.0-osx-arm64.tar.xz",
+            "integrity": "sha384-ZUd86mgaN6HKx/MzwkQxFwiM+yvX73m92u5NYuNZM5K8JQTf+hKeenf9F0X/9+xR",
+        },
+        "x86_64-apple-darwin": {
+            "url": "https://github.com/ldc-developers/ldc/releases/download/v1.42.0/ldc2-1.42.0-osx-x86_64.tar.xz",
+            "integrity": "sha384-MxX72T/o4lUUqMuhZWGPXK4HHsLE+1MsANDIR09nNWFhxIHIUkpPEVa+SVizlpkZ",
         },
     },
 }

--- a/tools/generate_compiler_versions_bzl.d
+++ b/tools/generate_compiler_versions_bzl.d
@@ -19,7 +19,7 @@ import integrity_hash : computeIntegrityHash;
 string GITHUB_API_URL = "https://api.github.com/repos";
 string GITHUB_LDC_REPO = "ldc-developers/ldc";
 
-string[] ARCHIVE_TYPES = [".tar.xz", ".zip"]; // in order of the preference
+string[] ARCHIVE_TYPES = [".tar.xz", ".zip", ".7z"]; // in order of the preference
 string[] OSES = ["linux", "osx", "windows"];
 string[] CPUS = ["aarch64", "amd64", "arm64", "x86_64"];
 string DMD_REPO_URL = "https://downloads.dlang.org";
@@ -31,7 +31,7 @@ struct CompilerReleaseInfo
     string version_; // "2.104.0", "1.39.0", ...
     string os; // "linux" | "macos" | "windows"
     string cpu; // "x86_64" | "aarch64" ...
-    string archive; // ".tar.xz" | ".zip"
+    string archive; // ".tar.xz" | ".zip" | ".7z"
     string url;
     string fileName;
     string integrity; // computed integrity metadata


### PR DESCRIPTION
Note that dmd-2.112.1 is published for windows as .7z archive which is supported by bazel 9.0.0 or newer